### PR TITLE
Initial port from opencost.yaml

### DIFF
--- a/Chart.yaml
+++ b/Chart.yaml
@@ -1,0 +1,5 @@
+apiVersion: v2
+appVersion: 1.9.8
+name: opencost
+description: Opencost and Opencost UI
+version:  0.0.1

--- a/README.md
+++ b/README.md
@@ -1,2 +1,10 @@
 # opencost-helm-chart
-OpenCost Helm chart 
+OpenCost Helm chart
+
+Based on https://raw.githubusercontent.com/opencost/opencost/develop/kubernetes/opencost.yaml
+
+
+# Links
+
+* https://github.com/opencost/opencost/tree/develop/kubernetes
+* https://www.opencost.io/docs/

--- a/templates/clusterrole.yaml
+++ b/templates/clusterrole.yaml
@@ -1,0 +1,79 @@
+# Cluster role giving opencost to get, list, watch required resources
+# No write permissions are required
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: opencost
+rules:
+  - apiGroups: [""]
+    resources:
+      - configmaps
+      - deployments
+      - nodes
+      - pods
+      - services
+      - resourcequotas
+      - replicationcontrollers
+      - limitranges
+      - persistentvolumeclaims
+      - persistentvolumes
+      - namespaces
+      - endpoints
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - extensions
+    resources:
+      - daemonsets
+      - deployments
+      - replicasets
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - apps
+    resources:
+      - statefulsets
+      - deployments
+      - daemonsets
+      - replicasets
+    verbs:
+      - list
+      - watch
+  - apiGroups:
+      - batch
+    resources:
+      - cronjobs
+      - jobs
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - autoscaling
+    resources:
+      - horizontalpodautoscalers
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - policy
+    resources:
+      - poddisruptionbudgets
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - storage.k8s.io
+    resources:
+      - storageclasses
+    verbs:
+      - get
+      - list
+      - watch
+

--- a/templates/clusterrolebinding.yaml
+++ b/templates/clusterrolebinding.yaml
@@ -1,0 +1,13 @@
+# Bind the role to the service account
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: opencost
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: opencost
+subjects:
+  - kind: ServiceAccount
+    name: opencost
+    namespace: {{ .Values.opencost.namespace.name }}

--- a/templates/deployment.yaml
+++ b/templates/deployment.yaml
@@ -25,41 +25,24 @@ spec:
     spec:
       serviceAccountName: opencost
       tolerations:
-        - key: availability
-          operator: Equal
-          value: spot
-          effect: NoExecute
-        - key: workload
-          operator: Equal
-          value: infra
-          effect: NoExecute
+        {{- toYaml .Values.opencost.tolerations | nindent 8 }}
       containers:
         - image: "{{ .Values.opencost.exporter.image.repository }}:{{ .Values.opencost.exporter.image.tag }}"
           name: {{ .Values.opencost.exporter.name }}
           resources:
-            requests:
-              cpu: "10m"
-              memory: "55M"
-            limits:
-              cpu: "999m"
-              memory: "1G"
+            {{- toYaml .Values.opencost.exporter.resources | nindent 12 }}
           env:
             - name: PROMETHEUS_SERVER_ENDPOINT
               value: "http://{{ .Values.opencost.prometheus.serviceName }}.{{ .Values.opencost.prometheus.namespaceName }}.svc" # The endpoint should have the form http://<service-name>.<namespace-name>.svc
             - name: CLOUD_PROVIDER_API_KEY
-              value: "AIzaSyD29bGxmHAVEOBYtgd8sYM2gM2ekfxQX4U" # The GCP Pricing API requires a key. This is supplied just for evaluation.
+              value: {{ .Values.opencost.exporter.cloudProviderApiKey | quote }}
             - name: CLUSTER_ID
-              value: "default-cluster" # Default cluster ID to use if cluster_id is not set in Prometheus metrics.
+              value: {{ .Values.opencost.exporter.defaultClusterId | quote }}
           imagePullPolicy: Always
-        {{- if .Values.opencost.ui.enabled -}}
+        {{- if .Values.opencost.ui.enabled }}
         - image: "{{ .Values.opencost.ui.image.repository }}:{{ .Values.opencost.ui.image.tag }}"
           name: opencost-ui
           resources:
-            requests:
-              cpu: "10m"
-              memory: "55M"
-            limits:
-              cpu: "999m"
-              memory: "1G"
+            {{- toYaml .Values.opencost.ui.resources | nindent 12 }}
           imagePullPolicy: Always
         {{- end -}}

--- a/templates/deployment.yaml
+++ b/templates/deployment.yaml
@@ -1,0 +1,65 @@
+# Create a deployment for a single cost model pod
+#
+# See environment variables if you would like to add a Prometheus for
+# cost model to read from for full functionality.
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ .Values.opencost.fullname }}
+  labels:
+    app: opencost
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: opencost
+  strategy:
+    rollingUpdate:
+      maxSurge: 1
+      maxUnavailable: 1
+    type: RollingUpdate
+  template:
+    metadata:
+      labels:
+        app: opencost
+    spec:
+      serviceAccountName: opencost
+      tolerations:
+        - key: availability
+          operator: Equal
+          value: spot
+          effect: NoExecute
+        - key: workload
+          operator: Equal
+          value: infra
+          effect: NoExecute
+      containers:
+        - image: "{{ .Values.opencost.exporter.image.repository }}:{{ .Values.opencost.exporter.image.tag }}"
+          name: {{ .Values.opencost.exporter.name }}
+          resources:
+            requests:
+              cpu: "10m"
+              memory: "55M"
+            limits:
+              cpu: "999m"
+              memory: "1G"
+          env:
+            - name: PROMETHEUS_SERVER_ENDPOINT
+              value: "http://{{ .Values.opencost.prometheus.serviceName }}.{{ .Values.opencost.prometheus.namespaceName }}.svc" # The endpoint should have the form http://<service-name>.<namespace-name>.svc
+            - name: CLOUD_PROVIDER_API_KEY
+              value: "AIzaSyD29bGxmHAVEOBYtgd8sYM2gM2ekfxQX4U" # The GCP Pricing API requires a key. This is supplied just for evaluation.
+            - name: CLUSTER_ID
+              value: "default-cluster" # Default cluster ID to use if cluster_id is not set in Prometheus metrics.
+          imagePullPolicy: Always
+        {{- if .Values.opencost.ui.enabled -}}
+        - image: "{{ .Values.opencost.ui.image.repository }}:{{ .Values.opencost.ui.image.tag }}"
+          name: opencost-ui
+          resources:
+            requests:
+              cpu: "10m"
+              memory: "55M"
+            limits:
+              cpu: "999m"
+              memory: "1G"
+          imagePullPolicy: Always
+        {{- end -}}

--- a/templates/namespace.yaml
+++ b/templates/namespace.yaml
@@ -1,0 +1,8 @@
+{{- if .Values.opencost.namespace.create -}}
+# The namespace opencost will run in
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: {{ .Values.opencost.namespace.name }}
+{{- end -}}
+

--- a/templates/service.yaml
+++ b/templates/service.yaml
@@ -1,0 +1,22 @@
+# Expose the cost model with a service
+#
+# Without a Prometheus endpoint configured in the deployment,
+# only opencost/metrics will have useful data as it is intended
+# to be used as just an exporter.
+kind: Service
+apiVersion: v1
+metadata:
+  name: {{ .Values.opencost.fullname }}
+spec:
+  selector:
+    app: opencost
+  type: ClusterIP
+  ports:
+    - name: {{ .Values.opencost.exporter.name }}
+      port: 9003
+      targetPort: 9003
+    {{- if .Values.opencost.ui.enabled -}}
+    - name: opencost-ui
+      port: 9090
+      targetPort: 9090
+    {{- end -}}

--- a/templates/service.yaml
+++ b/templates/service.yaml
@@ -15,7 +15,7 @@ spec:
     - name: {{ .Values.opencost.exporter.name }}
       port: 9003
       targetPort: 9003
-    {{- if .Values.opencost.ui.enabled -}}
+    {{- if .Values.opencost.ui.enabled }}
     - name: opencost-ui
       port: 9090
       targetPort: 9090

--- a/templates/serviceaccount.yaml
+++ b/templates/serviceaccount.yaml
@@ -1,0 +1,5 @@
+# Service account for permissions
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: opencost

--- a/values.yaml
+++ b/values.yaml
@@ -2,9 +2,18 @@ opencost:
   fullname: opencost
   exporter:
     name: opencost
+    cloudProviderApiKey:  "AIzaSyD29bGxmHAVEOBYtgd8sYM2gM2ekfxQX4U" # The GCP Pricing API requires a key. This is supplied just for evaluation.
+    defaultClusterId: "default-cluster" # Default cluster ID to use if cluster_id is not set in Prometheus metrics.
     image:
       repository:  quay.io/kubecost1/kubecost-cost-model
       tag: latest
+    resources:
+      requests:
+        cpu: "10m"
+        memory: "55M"
+      limits:
+        cpu: "999m"
+        memory: "1G"
 
   namespace:
     create: true
@@ -19,3 +28,12 @@ opencost:
     image:
       repository: quay.io/kubecost1/opencost-ui
       tag: latest
+    resources:
+      requests:
+        cpu: "10m"
+        memory: "55M"
+      limits:
+        cpu: "999m"
+        memory: "1G"
+
+  tolerations: []

--- a/values.yaml
+++ b/values.yaml
@@ -1,0 +1,21 @@
+opencost:
+  fullname: opencost
+  exporter:
+    name: opencost
+    image:
+      repository:  quay.io/kubecost1/kubecost-cost-model
+      tag: latest
+
+  namespace:
+    create: true
+    name: opencost
+
+  prometheus:
+    serviceName: my-prometheus
+    namespaceName: opencost
+
+  ui:
+    enabled: true
+    image:
+      repository: quay.io/kubecost1/opencost-ui
+      tag: latest


### PR DESCRIPTION
Split out https://github.com/opencost/opencost/tree/develop/kubernetes/opencost.yaml and added a few initial template values. 

Should produce the same result `opencost.yaml`. 

Signed-off-by: Liam Newman <liam@verta.ai>