### PR TITLE
Fixes #13 Additional labels in servicemonitor.yaml template

### DIFF
--- a/templates/servicemonitor.yaml
+++ b/templates/servicemonitor.yaml
@@ -8,6 +8,9 @@ metadata:
 {{- end }}
   labels:
     {{- include "opencost.labels" . | nindent 4 }}
+    {{- if .Values.opencost.metrics.serviceMonitor.additionalLabels }}
+    {{- toYaml .Values.opencost.metrics.serviceMonitor.additionalLabels | nindent 4 }}
+    {{- end }}
 spec:
   endpoints:
     - port: http


### PR DESCRIPTION
Fixes #13  `servicemonitor.yaml` template to include additional labels based on `values.yaml`