### PR TITLE
Adding RequestScheme in prometheus service endpoint

### DIFF
--- a/templates/_helpers.tpl
+++ b/templates/_helpers.tpl
@@ -75,7 +75,7 @@ Create the name of the controller service account to use
     {{- $host := .Values.opencost.prometheus.internal.serviceName }}
     {{- $ns := .Values.opencost.prometheus.internal.namespaceName }}
     {{- $port := .Values.opencost.prometheus.internal.port | int }}
-    {{- printf "%s.%s:%d" $host $ns $port -}}
+    {{- printf "http://%s.%s:%d" $host $ns $port -}}
 {{- end -}}
 {{- end -}}
 


### PR DESCRIPTION

```
12) Errors:
  Request Error: Error: Post "10.104.56.252/api/v1/query_range?end=2023-02-09T08%3A00%3A00Z&query=avg_over_time%28deployment_match_labels%5B1h%5D%29&start=2023-02-08T08%3A00%3A00Z&step=3600.000": unsupported protocol scheme "", Body:  Query: avg_over_time(deployment_match_labels[1h])
  Parse Error: Prometheus communication error: avg_over_time(deployment_match_labels[1h])
for Query: avg_over_time(deployment_match_labels[1h])
```

Signed-off-by: Rohit Raut <59472818+rohitraut3366@users.noreply.github.com>