### PR TITLE
feature: add nodeSelector, affinity and topologySpreadConstraint to Helm Chart

### DIFF
--- a/Chart.yaml
+++ b/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 appVersion: 1.9.8
 name: opencost
 description: OpenCost and OpenCost UI
-version: 1.0.0
+version: 1.1.0
 maintainers:
   - name: mattray
     url: https://mattray.dev

--- a/templates/deployment.yaml
+++ b/templates/deployment.yaml
@@ -30,6 +30,18 @@ spec:
       serviceAccountName: {{ template "opencost.serviceAccountName" . }}
       tolerations:
         {{- toYaml .Values.opencost.tolerations | nindent 8 }}
+      {{- with .Values.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with.Values.topologySpreadConstraints }}
+      topologySpreadConstraints:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       containers:
         - image: "{{ .Values.opencost.exporter.image.registry }}/{{ .Values.opencost.exporter.image.repository }}:{{ .Values.opencost.exporter.image.tag }}"
           name: {{ include "opencost.fullname" . }}

--- a/templates/deployment.yaml
+++ b/templates/deployment.yaml
@@ -30,15 +30,15 @@ spec:
       serviceAccountName: {{ template "opencost.serviceAccountName" . }}
       tolerations:
         {{- toYaml .Values.opencost.tolerations | nindent 8 }}
-      {{- with .Values.nodeSelector }}
+      {{- with .Values.opencost.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}
       {{- end }}
-      {{- with .Values.affinity }}
+      {{- with .Values.opencost.affinity }}
       affinity:
         {{- toYaml . | nindent 8 }}
       {{- end }}
-      {{- with.Values.topologySpreadConstraints }}
+      {{- with.Values.opencost.topologySpreadConstraints }}
       topologySpreadConstraints:
         {{- toYaml . | nindent 8 }}
       {{- end }}

--- a/values.yaml
+++ b/values.yaml
@@ -77,3 +77,6 @@ opencost:
         memory: '1G'
 
   tolerations: []
+  nodeSelector: {}
+  affinity: {}
+  topologySpreadConstraints: []


### PR DESCRIPTION
Fixes #16

Added the following config in Deployment template and to Chart default values.yaml:

- affinity
- nodeSelector
- topologySpreadConstraint

And updated the version in the Chart.yaml and in the raw manifest files.