### PR TITLE
Fix invalid helm template in deployment.yaml

### DIFF
--- a/templates/deployment.yaml
+++ b/templates/deployment.yaml
@@ -41,7 +41,7 @@ spec:
           env:
             - name: PROMETHEUS_SERVER_ENDPOINT
               value: {{ include "opencost.prometheusServerEndpoint" . | quote }}
-            {{- if .Values.opencost.exporter.cloudProviderApiKey }}}
+            {{- if .Values.opencost.exporter.cloudProviderApiKey }}
             - name: CLOUD_PROVIDER_API_KEY
               value: {{ .Values.opencost.exporter.cloudProviderApiKey | quote }}
             {{- end }}


### PR DESCRIPTION
The extra `}` results in a templating failure:
```
Error: YAML parse error on opencost/templates/deployment.yaml: error converting YAML to JSON: yaml: line 47: did not find expected key
helm.go:84: [debug] error converting YAML to JSON: yaml: line 47: did not find expected key
YAML parse error on opencost/templates/deployment.yaml
```