### PR TITLE
add pod annotation and make secret object optional

### DIFF
--- a/charts/opencost/templates/deployment.yaml
+++ b/charts/opencost/templates/deployment.yaml
@@ -20,6 +20,10 @@ spec:
       maxUnavailable: 1
     type: RollingUpdate
   template:
+      {{- with .Values.podAnnotations }}
+      annotations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
     metadata:
       labels:
         {{- include "opencost.selectorLabels" . | nindent 8 }}
@@ -59,7 +63,7 @@ spec:
             {{- end }}
             - name: CLUSTER_ID
               value: {{ .Values.opencost.exporter.defaultClusterId | quote }}
-            # If username and password are defined, pull from secrets
+            # If username, password or bearer_token are defined, pull from secrets
             {{- if .Values.opencost.prometheus.username }}
             - name: DB_BASIC_AUTH_USERNAME
               valueFrom:
@@ -73,6 +77,13 @@ spec:
                 secretKeyRef:
                   name: {{ include "opencost.fullname" . }}
                   key: DB_BASIC_AUTH_PW
+            {{- end }}
+            {{- if .Values.opencost.prometheus.bearer_token }}
+            - name: DB_BEARER_TOKEN
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "opencost.fullname" . }}
+                  key: DB_BEARER_TOKEN
             {{- end }}
             # Add any additional provided variables
             {{- range $key, $value := .Values.opencost.exporter.extraEnv }}

--- a/charts/opencost/templates/deployment.yaml
+++ b/charts/opencost/templates/deployment.yaml
@@ -20,10 +20,10 @@ spec:
       maxUnavailable: 1
     type: RollingUpdate
   template:
-      {{- with .Values.podAnnotations }}
-      annotations:
-        {{- toYaml . | nindent 8 }}
-      {{- end }}
+    {{- with .Values.podAnnotations }}
+    annotations:
+      {{- toYaml . | nindent 8 }}
+    {{- end }}
     metadata:
       labels:
         {{- include "opencost.selectorLabels" . | nindent 8 }}

--- a/charts/opencost/templates/deployment.yaml
+++ b/charts/opencost/templates/deployment.yaml
@@ -77,8 +77,7 @@ spec:
                 secretKeyRef:
                   name: {{ include "opencost.fullname" . }}
                   key: DB_BASIC_AUTH_PW
-            {{- end }}
-            {{- if .Values.opencost.prometheus.bearer_token }}
+            {{- else if .Values.opencost.prometheus.bearer_token }}
             - name: DB_BEARER_TOKEN
               valueFrom:
                 secretKeyRef:

--- a/charts/opencost/templates/secret.yaml
+++ b/charts/opencost/templates/secret.yaml
@@ -1,3 +1,4 @@
+{{- if or .Values.opencost.prometheus.username .Values.opencost.prometheus.password .Values.opencost.prometheus.bearer_token -}}
 apiVersion: v1
 kind: Secret
 metadata:
@@ -12,3 +13,7 @@ data:
   {{- if .Values.opencost.prometheus.password }}
   DB_BASIC_AUTH_PW: {{ .Values.opencost.prometheus.password | b64enc | quote }}
   {{- end }}
+  {{- if .Values.opencost.prometheus.bearer_token }}
+  DB_BEARER_TOKEN: {{ .Values.opencost.prometheus.bearer_token | b64enc | quote }}
+  {{- end }}
+{{- end }}

--- a/charts/opencost/values.yaml
+++ b/charts/opencost/values.yaml
@@ -6,6 +6,8 @@ serviceAccount:
 
 annotations: {}
 
+podAnnotations: {}
+
 service:
   annotations: {}
   labels: {}
@@ -53,6 +55,7 @@ opencost:
   prometheus:
     # username:
     # password:
+    # bearer_token:
     external:
       enabled: false
       url: 'https://mimir-dev-push.infra.alto.com/prometheus'


### PR DESCRIPTION
- Adding ability to annotate pods
- Making secret creation optional based on the secret values
- Adding option to add bearer token for prometheus
- Updated values.yaml accordingly