### PR TITLE
fix,chore: Plain text of API key

### DIFF
--- a/charts/opencost/Chart.yaml
+++ b/charts/opencost/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 appVersion: 1.9.8
 name: opencost
 description: OpenCost and OpenCost UI
-version: 1.1.0
+version: 1.1.1
 maintainers:
   - name: mattray
     url: https://mattray.dev

--- a/charts/opencost/templates/deployment.yaml
+++ b/charts/opencost/templates/deployment.yaml
@@ -78,6 +78,9 @@ spec:
                   name: {{ include "opencost.fullname" . }}
                   key: DB_BASIC_AUTH_PW
             {{- end }}
+            {{- with .Values.opencost.exporter.env }}
+            {{- toYaml . | nindent 12 }}
+            {{- end }}
             # Add any additional provided variables
             {{- range $key, $value := .Values.opencost.exporter.extraEnv }}
             - name: {{ $key }}


### PR DESCRIPTION
I use GitOps tool like FluxCD or ArgoCD. So, the code gets versioned.

So I needed to put an API key of GCP... but the `opencost.exporter.cloudProviderApiKey` is vulnerable. My security scanner argues about it.

Usually we could use a Kubernetes Secret that can be read from an Env. Like this

```
opencost:
  exporter:
    defaultClusterId: 'default-cluster'
    env:
    - name: CLOUD_PROVIDER_API_KEY
      valueFrom:
        secretKeyRef:
          name: some-safety-secret
          key: key
```

It's fine. It's standard. So I'm sure the OpenCost Helm Chart can support it too.

Ah! I tested it with no problem, you can do so.

```
helm template --dry-run .
```

Please, I need this fix/feature. Can you help me out?