### PR TITLE
chore(chart): Bump version a minor number for #24

### DIFF
--- a/charts/opencost/Chart.yaml
+++ b/charts/opencost/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 appVersion: 1.9.8
 name: opencost
 description: OpenCost and OpenCost UI
-version: 1.1.0
+version: 1.2.0
 maintainers:
   - name: mattray
     url: https://mattray.dev


### PR DESCRIPTION
I merged #24 without bumping the semver which resulted in the publish artifact stage to fail due to conflicting tag names. 

This change bumps to `1.2.0`, which should reflect the minor changes added.