### PR TITLE
fix the location of annotations for pods

### DIFF
--- a/charts/opencost/Chart.yaml
+++ b/charts/opencost/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 appVersion: 1.9.8
 name: opencost
 description: OpenCost and OpenCost UI
-version: 1.2.0
+version: 1.3.0
 maintainers:
   - name: mattray
     url: https://mattray.dev

--- a/charts/opencost/templates/deployment.yaml
+++ b/charts/opencost/templates/deployment.yaml
@@ -23,9 +23,9 @@ spec:
     metadata:
       labels:
         {{- include "opencost.selectorLabels" . | nindent 8 }}
-      {{- with .Values.podAnnotations }}
+      {{- if .Values.podAnnotations }}
       annotations:
-        {{- toYaml . | nindent 8 }}
+      {{- toYaml .Values.podAnnotations | nindent 8 }}
       {{- end }}
     spec:
     {{- if .Values.imagePullSecrets }}

--- a/charts/opencost/templates/deployment.yaml
+++ b/charts/opencost/templates/deployment.yaml
@@ -20,13 +20,13 @@ spec:
       maxUnavailable: 1
     type: RollingUpdate
   template:
-    {{- with .Values.podAnnotations }}
-    annotations:
-      {{- toYaml . | nindent 8 }}
-    {{- end }}
     metadata:
       labels:
         {{- include "opencost.selectorLabels" . | nindent 8 }}
+      {{- with .Values.podAnnotations }}
+      annotations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
     spec:
     {{- if .Values.imagePullSecrets }}
       imagePullSecrets: {{ toYaml .Values.imagePullSecrets | nindent 8 }}


### PR DESCRIPTION
Fixing the incorrect location for the pod annotation in https://github.com/opencost/opencost-helm-chart/pull/24 and also bumped the version to avoid the version issues.

@Pokom I noticed that issue while deploying, so apologies for the back and forth, can you take a look please?