### PR TITLE
chore: Adapt workflow to common helm testing

### DIFF
--- a/.github/configs/ct.yaml
+++ b/.github/configs/ct.yaml
@@ -1,0 +1,13 @@
+## Reference: https://github.com/helm/chart-testing/blob/master/doc/ct_lint-and-install.md
+# Don't add the 'debug' attribute, otherwise the workflow won't work anymore
+# Only Used for the CT Lint Stage
+remote: origin
+target-branch: main
+chart-dirs:
+  - charts
+chart-repos: []
+validate-chart-schema: false
+validate-maintainers: true
+validate-yaml: true
+exclude-deprecated: true
+excluded-charts: []

--- a/.github/configs/lintconf.yaml
+++ b/.github/configs/lintconf.yaml
@@ -1,0 +1,42 @@
+---
+rules:
+  braces:
+    min-spaces-inside: 0
+    max-spaces-inside: 0
+    min-spaces-inside-empty: -1
+    max-spaces-inside-empty: -1
+  brackets:
+    min-spaces-inside: 0
+    max-spaces-inside: 0
+    min-spaces-inside-empty: -1
+    max-spaces-inside-empty: -1
+  colons:
+    max-spaces-before: 0
+    max-spaces-after: 1
+  commas:
+    max-spaces-before: 0
+    min-spaces-after: 1
+    max-spaces-after: 1
+  comments:
+    require-starting-space: true
+    min-spaces-from-content: 1
+  document-end: disable
+  document-start: disable # No --- to start a file
+  empty-lines:
+    max: 2
+    max-start: 0
+    max-end: 0
+  hyphens:
+    max-spaces-after: 1
+  indentation:
+    spaces: consistent
+    indent-sequences: whatever # - list indentation will handle both indentation and without
+    check-multi-line-strings: false
+  key-duplicates: enable
+  line-length: disable # Lines can be any length
+  new-line-at-end-of-file: enable
+  new-lines:
+    type: unix
+  trailing-spaces: enable
+  truthy:
+    level: warning

--- a/.github/workflows/helm-test.yml
+++ b/.github/workflows/helm-test.yml
@@ -34,35 +34,24 @@ jobs:
       - name: Set up chart-testing
         uses: helm/chart-testing-action@v2.3.1
 
-      - name: Get changed files in the docs folder
-        id: files-changed
-        uses: tj-actions/changed-files@v35
-        with:
-          files: |
-            charts/**
-
-      # change detection in ct seems to not detect some changes. Using simple file modification for now.
-      # - name: Run chart-testing (list-changed)
-      #   id: list-changed
-      #   run: |
-      #     changed=$(ct list-changed --chart-dirs . --target-branch ${{ github.event.repository.default_branch }})
-      #     if [[ -n "$changed" ]]; then
-      #       echo "chart-changed=true" >> $GITHUB_OUTPUT
-      #     fi
-      # - name: Run chart-testing (lint changed)
-      #   run: ct lint --chart-dirs . --target-branch ${{ github.event.repository.default_branch }}
+      - name: List changed charts
+        id: list-changed
+        run: |
+          ## If executed with debug this won't work anymore.
+          changed=$(ct --config ./.github/configs/ct.yaml list-changed)
+          charts=$(echo "$changed" | tr '\n' ' ' | xargs)
+          if [[ -n "$changed" ]]; then
+            echo "changed=true" >> $GITHUB_STATE
+            echo "changed_charts=$charts" >> $GITHUB_STATE
+          fi
 
       - name: Run chart-testing (lint)
-        run: ct lint --all
+        run: ct lint --debug --config ./.github/configs/ct.yaml --lint-conf ./.github/configs/lintconf.yaml
 
       - name: Create kind cluster
         uses: helm/kind-action@v1.4.0
-        # if: steps.list-changed.outputs.chart-changed == 'true' || steps.files-changed.outputs.any_modified == 'true'
-        if: steps.files-changed.outputs.any_modified == 'true'
-
-      # - name: Run chart-testing (install changed)
-      #  run: ct install --chart-dirs . --target-branch ${{ github.event.repository.default_branch }} --upgrade 
+        if: steps.list-changed.outputs.changed == 'true'
 
       - name: Run chart-testing (install)
-        run: ct install --all
-        if: steps.files-changed.outputs.any_modified == 'true'
+        run: ct install --config ./.github/configs/ct.yaml
+        if: steps.list-changed.outputs.changed == 'true'


### PR DESCRIPTION
I ([argo-helm](https://github.com/argoproj/argo-helm) maintainer) would like to share our workflow for CI testing.

Resolves #30

Tested it on my fork repo:
<img width="1012" alt="grafik" src="https://user-images.githubusercontent.com/7290987/225117383-9b728940-4ac9-4ef5-8aee-b351ab9dd424.png">

The code is mostly based on the howto/README of the [helm/chart-testing-action](https://github.com/helm/chart-testing-action).
The only thing we (at argo-helm) recently adapted is to remove the deprecated `echo "::set-output name=changed::true"` with `echo "changed=true" >> $GITHUB_STATE`.

Deprecation and howto fix is documented in the GitHub blog post: https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/#examples