### PR TITLE
Support configurable number of replicas on the deployment

### DIFF
--- a/charts/opencost/Chart.yaml
+++ b/charts/opencost/Chart.yaml
@@ -9,7 +9,7 @@ keywords:
   - kubecost
   - opencost
   - monitoring
-version: 1.4.0
+version: 1.5.0
 maintainers:
   - name: mattray
     url: https://mattray.dev

--- a/charts/opencost/README.md
+++ b/charts/opencost/README.md
@@ -2,9 +2,9 @@
 
 OpenCost and OpenCost UI
 
-![Version: 1.4.0](https://img.shields.io/badge/Version-1.4.0-informational?style=flat-square)
+![Version: 1.5.0](https://img.shields.io/badge/Version-1.5.0-informational?style=flat-square)
 ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
-![AppVersion: 1.100.2](https://img.shields.io/badge/AppVersion-1.100.2-informational?style=flat-square)
+![AppVersion: 1.101.2](https://img.shields.io/badge/AppVersion-1.101.2-informational?style=flat-square)
 
 ## Maintainers
 
@@ -34,6 +34,7 @@ $ helm install opencost opencost/opencost
 | opencost.exporter.image.registry | string | `"quay.io"` | Exporter container image registry |
 | opencost.exporter.image.repository | string | `"kubecost1/kubecost-cost-model"` | Exporter container image name |
 | opencost.exporter.image.tag | string | `""` (use appVersion in Chart.yaml) | Exporter container image tag |
+| opencost.exporter.replicas | int | `1` | Number of OpenCost replicas to run |
 | opencost.exporter.resources.limits | object | `{"cpu":"999m","memory":"1Gi"}` | CPU/Memory resource limits |
 | opencost.exporter.resources.requests | object | `{"cpu":"10m","memory":"55Mi"}` | CPU/Memory resource requests |
 | opencost.metrics.serviceMonitor.additionalLabels | object | `{}` | Additional labels to add to the ServiceMonitor |

--- a/charts/opencost/templates/deployment.yaml
+++ b/charts/opencost/templates/deployment.yaml
@@ -10,7 +10,7 @@ metadata:
   annotations: {{ toYaml .Values.annotations | nindent 4 }}
   {{- end }}
 spec:
-  replicas: 1
+  replicas: {{ .Values.opencost.exporter.replicas }}
   selector:
     matchLabels:
       {{- include "opencost.selectorLabels" . | nindent 6 }}

--- a/charts/opencost/values.yaml
+++ b/charts/opencost/values.yaml
@@ -35,6 +35,8 @@ opencost:
       # -- Exporter container image tag
       # @default -- `""` (use appVersion in Chart.yaml)
       tag: ""
+    # -- Number of OpenCost replicas to run
+    replicas: 1
     resources:
       # -- CPU/Memory resource requests
       requests:


### PR DESCRIPTION
Fixes https://github.com/opencost/opencost-helm-chart/issues/33

Default remains 1 replica
