### PR TITLE
feat: Add ability to define securityContexts and podSecurityContext

### DIFF
--- a/charts/opencost/Chart.yaml
+++ b/charts/opencost/Chart.yaml
@@ -9,7 +9,7 @@ keywords:
   - kubecost
   - opencost
   - monitoring
-version: 1.5.0
+version: 1.6.0
 maintainers:
   - name: mattray
     url: https://mattray.dev

--- a/charts/opencost/README.md
+++ b/charts/opencost/README.md
@@ -2,7 +2,7 @@
 
 OpenCost and OpenCost UI
 
-![Version: 1.5.0](https://img.shields.io/badge/Version-1.5.0-informational?style=flat-square)
+![Version: 1.6.0](https://img.shields.io/badge/Version-1.6.0-informational?style=flat-square)
 ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
 ![AppVersion: 1.101.2](https://img.shields.io/badge/AppVersion-1.101.2-informational?style=flat-square)
 
@@ -37,6 +37,7 @@ $ helm install opencost opencost/opencost
 | opencost.exporter.replicas | int | `1` | Number of OpenCost replicas to run |
 | opencost.exporter.resources.limits | object | `{"cpu":"999m","memory":"1Gi"}` | CPU/Memory resource limits |
 | opencost.exporter.resources.requests | object | `{"cpu":"10m","memory":"55Mi"}` | CPU/Memory resource requests |
+| opencost.exporter.securityContext | object | `{}` | The security options the container should be run with |
 | opencost.metrics.serviceMonitor.additionalLabels | object | `{}` | Additional labels to add to the ServiceMonitor |
 | opencost.metrics.serviceMonitor.enabled | bool | `false` | Create ServiceMonitor resource for scraping metrics using PrometheusOperator |
 | opencost.metrics.serviceMonitor.honorLabels | bool | `false` | HonorLabels chooses the metric's labels on collisions with target labels |
@@ -62,7 +63,9 @@ $ helm install opencost opencost/opencost
 | opencost.ui.image.tag | string | `""` (use appVersion in Chart.yaml) | UI container image tag |
 | opencost.ui.resources.limits | object | `{"cpu":"999m","memory":"1Gi"}` | CPU/Memory resource limits |
 | opencost.ui.resources.requests | object | `{"cpu":"10m","memory":"55Mi"}` | CPU/Memory resource requests |
+| opencost.ui.securityContext | object | `{}` | The security options the container should be run with |
 | podAnnotations | object | `{}` | Annotations to add to the OpenCost Pod |
+| podSecurityContext | object | `{}` | Holds pod-level security attributes and common container settings |
 | service.annotations | object | `{}` | Annotations to add to the service |
 | service.labels | object | `{}` | Labels to add to the service account |
 | service.type | string | `"ClusterIP"` | Kubernetes Service type |

--- a/charts/opencost/templates/deployment.yaml
+++ b/charts/opencost/templates/deployment.yaml
@@ -31,6 +31,8 @@ spec:
     {{- if .Values.imagePullSecrets }}
       imagePullSecrets: {{ toYaml .Values.imagePullSecrets | nindent 8 }}
     {{- end }}
+      securityContext:
+        {{- toYaml .Values.podSecurityContext | nindent 8 }}
       serviceAccountName: {{ template "opencost.serviceAccountName" . }}
       tolerations:
         {{- toYaml .Values.opencost.tolerations | nindent 8 }}
@@ -54,6 +56,8 @@ spec:
           ports:
             - containerPort: 9003
               name: http
+          securityContext:
+            {{- toYaml .Values.opencost.exporter.securityContext | nindent 12 }}
           volumeMounts:
           {{- if .Values.opencost.exporter.extraVolumeMounts }}
           {{- toYaml .Values.opencost.exporter.extraVolumeMounts | nindent 12 }}
@@ -106,6 +110,8 @@ spec:
           ports:
             - containerPort: 9090
               name: http-ui
+          securityContext:
+            {{- toYaml .Values.opencost.ui.securityContext | nindent 12 }}
         {{- end }}
       volumes:
       {{- if .Values.extraVolumes }}

--- a/charts/opencost/values.yaml
+++ b/charts/opencost/values.yaml
@@ -13,6 +13,10 @@ annotations: {}
 # --  Annotations to add to the OpenCost Pod
 podAnnotations: {}
 
+# -- Holds pod-level security attributes and common container settings
+podSecurityContext: {}
+  # fsGroup: 2000
+
 service:
   # --  Annotations to add to the service
   annotations: {}
@@ -46,6 +50,15 @@ opencost:
       limits:
         cpu: '999m'
         memory: '1Gi'
+    # -- The security options the container should be run with
+    securityContext: {}
+      # capabilities:
+      #   drop:
+      #   - ALL
+      # readOnlyRootFilesystem: true
+      # runAsNonRoot: true
+      # runAsUser: 1000
+
     # -- A list of volume mounts to be added to the pod
     extraVolumeMounts: []
     # -- Any extra environment variables you would like to pass on to the pod
@@ -111,6 +124,14 @@ opencost:
       limits:
         cpu: '999m'
         memory: '1Gi'
+    # -- The security options the container should be run with
+    securityContext: {}
+      # capabilities:
+      #   drop:
+      #   - ALL
+      # readOnlyRootFilesystem: true
+      # runAsNonRoot: true
+      # runAsUser: 1000
 
   # -- Toleration labels for pod assignment
   tolerations: []


### PR DESCRIPTION
This PR adds the ability to define the securityContext on both container- and pod-level.

/cc: @toscott @mattray @Pokom 