### PR TITLE
fix: Last PR (#35) contained a bug, replace GITHUB_STATE -> GITHUB_OUTPUT

### DIFF
--- a/.github/workflows/helm-test.yml
+++ b/.github/workflows/helm-test.yml
@@ -41,8 +41,8 @@ jobs:
           changed=$(ct --config ./.github/configs/ct.yaml list-changed)
           charts=$(echo "$changed" | tr '\n' ' ' | xargs)
           if [[ -n "$changed" ]]; then
-            echo "changed=true" >> $GITHUB_STATE
-            echo "changed_charts=$charts" >> $GITHUB_STATE
+            echo "changed=true" >> $GITHUB_OUTPUT
+            echo "changed_charts=$charts" >> $GITHUB_OUTPUT
           fi
 
       - name: Run chart-testing (lint)


### PR DESCRIPTION
Hi again

My last PR (#35) contained a bug which was also present in my main repository over there: [argoproj/argo-helm](https://github.com/argoproj/argo-helm).
So this one here is a "backport" of our fix:
- https://github.com/argoproj/argo-helm/pull/1904

/cc: @mattray @Pokom @toscott 