### PR TITLE
feat: Add ability to inject extraVolumeMounts into UI container

### DIFF
--- a/charts/opencost/Chart.yaml
+++ b/charts/opencost/Chart.yaml
@@ -9,7 +9,7 @@ keywords:
   - kubecost
   - opencost
   - monitoring
-version: 1.6.0
+version: 1.7.0
 maintainers:
   - name: mattray
     url: https://mattray.dev

--- a/charts/opencost/README.md
+++ b/charts/opencost/README.md
@@ -2,7 +2,7 @@
 
 OpenCost and OpenCost UI
 
-![Version: 1.6.0](https://img.shields.io/badge/Version-1.6.0-informational?style=flat-square)
+![Version: 1.7.0](https://img.shields.io/badge/Version-1.7.0-informational?style=flat-square)
 ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
 ![AppVersion: 1.101.2](https://img.shields.io/badge/AppVersion-1.101.2-informational?style=flat-square)
 
@@ -58,6 +58,7 @@ $ helm install opencost opencost/opencost
 | opencost.tolerations | list | `[]` | Toleration labels for pod assignment |
 | opencost.topologySpreadConstraints | list | `[]` | Assign custom TopologySpreadConstraints rules |
 | opencost.ui.enabled | bool | `true` | Enable OpenCost UI |
+| opencost.ui.extraVolumeMounts | list | `[]` | A list of volume mounts to be added to the pod |
 | opencost.ui.image.registry | string | `"quay.io"` | UI container image registry |
 | opencost.ui.image.repository | string | `"kubecost1/opencost-ui"` | UI container image name |
 | opencost.ui.image.tag | string | `""` (use appVersion in Chart.yaml) | UI container image tag |

--- a/charts/opencost/templates/deployment.yaml
+++ b/charts/opencost/templates/deployment.yaml
@@ -25,7 +25,7 @@ spec:
         {{- include "opencost.selectorLabels" . | nindent 8 }}
       {{- if .Values.podAnnotations }}
       annotations:
-      {{- toYaml .Values.podAnnotations | nindent 8 }}
+        {{- toYaml .Values.podAnnotations | nindent 8 }}
       {{- end }}
     spec:
     {{- if .Values.imagePullSecrets }}
@@ -58,9 +58,9 @@ spec:
               name: http
           securityContext:
             {{- toYaml .Values.opencost.exporter.securityContext | nindent 12 }}
+          {{- with .Values.opencost.exporter.extraVolumeMounts }}
           volumeMounts:
-          {{- if .Values.opencost.exporter.extraVolumeMounts }}
-          {{- toYaml .Values.opencost.exporter.extraVolumeMounts | nindent 12 }}
+            {{- toYaml . | nindent 12 }}
           {{- end }}
           env:
             - name: PROMETHEUS_SERVER_ENDPOINT
@@ -93,7 +93,7 @@ spec:
                   key: DB_BEARER_TOKEN
             {{- end }}
             {{- with .Values.opencost.exporter.env }}
-            {{- toYaml . | nindent 12 }}
+              {{- toYaml . | nindent 12 }}
             {{- end }}
             # Add any additional provided variables
             {{- range $key, $value := .Values.opencost.exporter.extraEnv }}
@@ -112,8 +112,12 @@ spec:
               name: http-ui
           securityContext:
             {{- toYaml .Values.opencost.ui.securityContext | nindent 12 }}
+          {{- with .Values.opencost.ui.extraVolumeMounts }}
+          volumeMounts:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
         {{- end }}
+      {{- with .Values.extraVolumes }}
       volumes:
-      {{- if .Values.extraVolumes }}
-      {{- toYaml .Values.extraVolumes | nindent 8 }}
+        {{- toYaml . | nindent 8 }}
       {{- end }}

--- a/charts/opencost/values.yaml
+++ b/charts/opencost/values.yaml
@@ -133,6 +133,9 @@ opencost:
       # runAsNonRoot: true
       # runAsUser: 1000
 
+    # -- A list of volume mounts to be added to the pod
+    extraVolumeMounts: []
+
   # -- Toleration labels for pod assignment
   tolerations: []
   # -- Node labels for pod assignment


### PR DESCRIPTION
Follow-up of discussion in PR:
- #38

> Just as a note to anyone leveraging this later, the UI container crashes if readOnlyRootFilesystem is true as it needs to write to tmp space.
> 
> [emerg] 1#1: mkdir() "/tmp/proxy_temp" failed (30: Read-only file system)
>
> _Source: @toscott , https://github.com/opencost/opencost-helm-chart/pull/38#discussion_r1138037333_