### PR TITLE
minor fixes to various services

### DIFF
--- a/charts/opencost/Chart.yaml
+++ b/charts/opencost/Chart.yaml
@@ -9,7 +9,7 @@ keywords:
   - kubecost
   - opencost
   - monitoring
-version: 1.11.0
+version: 1.11.1
 maintainers:
   - name: mattray
     url: https://mattray.dev

--- a/charts/opencost/README.md
+++ b/charts/opencost/README.md
@@ -2,9 +2,9 @@
 
 OpenCost and OpenCost UI
 
-![Version: 1.10.0](https://img.shields.io/badge/Version-1.10.0-informational?style=flat-square)
+![Version: 1.11.1](https://img.shields.io/badge/Version-1.11.1-informational?style=flat-square)
 ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
-![AppVersion: 1.101.2](https://img.shields.io/badge/AppVersion-1.101.2-informational?style=flat-square)
+![AppVersion: 1.102.0](https://img.shields.io/badge/AppVersion-1.102.0-informational?style=flat-square)
 
 ## Maintainers
 
@@ -25,7 +25,10 @@ $ helm install opencost opencost/opencost
 
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
-| annotations | object | `{}` | Annotations to add to the Deployment |
+| fullnameOverride | string | `""` | Overwrite all resources name created by the chart |
+| nameOverride | string | `""` | Overwrite the default name of the chart |
+| annotations | object | `{}` | Annotations to add to the all the resources|
+| rbac.enabled | bool | `true` | Specifies whether RBAC should be used | 
 | extraVolumes | list | `[]` | A list of volumes to be added to the pod |
 | opencost.affinity | object | `{}` | Affinity settings for pod assignment |
 | opencost.exporter.cloudProviderApiKey | string | `""` | The GCP Pricing API requires a key. This is supplied just for evaluation. |
@@ -76,6 +79,7 @@ $ helm install opencost opencost/opencost
 | podSecurityContext | object | `{}` | Holds pod-level security attributes and common container settings |
 | priorityClassName | string | `nil` | Pod priority |
 | secretAnnotations | object | `{}` | Annotations to add to the Secret |
+| service.enabled | bool | `true` | Enable service |
 | service.annotations | object | `{}` | Annotations to add to the service |
 | service.labels | object | `{}` | Labels to add to the service account |
 | service.type | string | `"ClusterIP"` | Kubernetes Service type |

--- a/charts/opencost/templates/clusterrolebinding.yaml
+++ b/charts/opencost/templates/clusterrolebinding.yaml
@@ -1,11 +1,14 @@
-# Bind the role to the service account
+{{- if .Values.rbac.enabled -}}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   labels:
     {{- include "opencost.labels" . | nindent 4 }}
   name: {{ include "opencost.fullname" . }}
-  namespace: {{ .Release.Namespace }}
+  {{- if .Values.annotations }}
+  annotations:
+    {{- toYaml .Values.annotations | nindent 4 }}
+  {{- end }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
@@ -14,3 +17,4 @@ subjects:
   - kind: ServiceAccount
     name: {{ template "opencost.serviceAccountName" . }}
     namespace: {{ .Release.Namespace }}
+{{- end -}}

--- a/charts/opencost/templates/service.yaml
+++ b/charts/opencost/templates/service.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.service.enabled -}}
 apiVersion: v1
 kind: Service
 metadata:
@@ -25,3 +26,4 @@ spec:
       port: 9090
       targetPort: 9090
     {{- end -}}
+{{- end -}}

--- a/charts/opencost/templates/serviceaccount.yaml
+++ b/charts/opencost/templates/serviceaccount.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.serviceAccount.create -}}
 apiVersion: v1
 kind: ServiceAccount
 metadata:
@@ -10,3 +11,4 @@ metadata:
   {{- toYaml .Values.serviceAccount.annotations | nindent 4 }}
   {{- end }}
 automountServiceAccountToken: {{ .Values.serviceAccount.automountServiceAccountToken }}
+{{- end }}

--- a/charts/opencost/values.yaml
+++ b/charts/opencost/values.yaml
@@ -1,3 +1,8 @@
+# -- Overwrite the default name of the chart
+nameOverride: ""
+# -- Overwrite all resources name created by the chart
+fullnameOverride: ""
+
 serviceAccount:
   # -- Specifies whether a service account should be created
   create: true
@@ -8,7 +13,7 @@ serviceAccount:
   # -- Whether pods running as this service account should have an API token automatically mounted
   automountServiceAccountToken: true
 
-# --  Annotations to add to the Deployment
+# --  Annotations to add to the all the resources
 annotations: {}
 # --  Annotations to add to the OpenCost Pod
 podAnnotations: {}
@@ -24,12 +29,17 @@ podSecurityContext: {}
   # fsGroup: 2000
 
 service:
+  enabled: true
   # --  Annotations to add to the service
   annotations: {}
   # --  Labels to add to the service account
   labels: {}
   # --  Kubernetes Service type
   type: ClusterIP
+
+# Create cluster role policies
+rbac:
+  enabled: true
 
 opencost:
   exporter:


### PR DESCRIPTION
minor fixes to various services:

- if `rbac` is enabled then create it + remove the namespace as it's applied to all namespace + annotations
- if `service` is enabled then create it 
- if `serviceAccount` is enabled then create it. It was missing from the chart but present on README.md and values.yaml
- updated the `values.yaml` with the above changes + minor correction to annotations: {} as the indentation is for `global`
-  update README.md 
- added fullnameOverride + nameOverride
- bump version
