### PR TITLE
chore: liveness and readiness probes

### DIFF
--- a/charts/opencost/Chart.yaml
+++ b/charts/opencost/Chart.yaml
@@ -9,7 +9,7 @@ keywords:
   - kubecost
   - opencost
   - monitoring
-version: 1.11.0
+version: 1.11.1
 maintainers:
   - name: mattray
     url: https://mattray.dev

--- a/charts/opencost/README.md
+++ b/charts/opencost/README.md
@@ -2,9 +2,9 @@
 
 OpenCost and OpenCost UI
 
-![Version: 1.10.0](https://img.shields.io/badge/Version-1.10.0-informational?style=flat-square)
+![Version: 1.11.0](https://img.shields.io/badge/Version-1.11.0-informational?style=flat-square)
 ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
-![AppVersion: 1.101.2](https://img.shields.io/badge/AppVersion-1.101.2-informational?style=flat-square)
+![AppVersion: 1.102.0](https://img.shields.io/badge/AppVersion-1.102.0-informational?style=flat-square)
 
 ## Maintainers
 
@@ -35,6 +35,16 @@ $ helm install opencost opencost/opencost
 | opencost.exporter.image.registry | string | `"quay.io"` | Exporter container image registry |
 | opencost.exporter.image.repository | string | `"kubecost1/kubecost-cost-model"` | Exporter container image name |
 | opencost.exporter.image.tag | string | `""` (use appVersion in Chart.yaml) | Exporter container image tag |
+| opencost.exporter.livenessProbe | object | `{"enabled":true,"failureThreshold":200,"initialDelaySeconds":30,"periodSeconds":10}` | Liveness probe configuration |
+| opencost.exporter.livenessProbe.enabled | bool | `true` | Whether probe is enabled |
+| opencost.exporter.livenessProbe.failureThreshold | int | `200` | Number of failures for probe to be considered failed |
+| opencost.exporter.livenessProbe.initialDelaySeconds | int | `30` | Number of seconds before probe is initiated |
+| opencost.exporter.livenessProbe.periodSeconds | int | `10` | Probe frequency in seconds |
+| opencost.exporter.readinessProbe | object | `{"enabled":true,"failureThreshold":200,"initialDelaySeconds":30,"periodSeconds":10}` | Readiness probe configuration |
+| opencost.exporter.readinessProbe.enabled | bool | `true` | Whether probe is enabled |
+| opencost.exporter.readinessProbe.failureThreshold | int | `200` | Number of failures for probe to be considered failed |
+| opencost.exporter.readinessProbe.initialDelaySeconds | int | `30` | Number of seconds before probe is initiated |
+| opencost.exporter.readinessProbe.periodSeconds | int | `10` | Probe frequency in seconds |
 | opencost.exporter.replicas | int | `1` | Number of OpenCost replicas to run |
 | opencost.exporter.resources.limits | object | `{"cpu":"999m","memory":"1Gi"}` | CPU/Memory resource limits |
 | opencost.exporter.resources.requests | object | `{"cpu":"10m","memory":"55Mi"}` | CPU/Memory resource requests |
@@ -63,11 +73,20 @@ $ helm install opencost opencost/opencost
 | opencost.ui.image.registry | string | `"quay.io"` | UI container image registry |
 | opencost.ui.image.repository | string | `"kubecost1/opencost-ui"` | UI container image name |
 | opencost.ui.image.tag | string | `""` (use appVersion in Chart.yaml) | UI container image tag |
-| opencost.ui.ingress.annotations | object | `{}` | Annotations for Ingress resource |
-| opencost.ui.ingress.enabled | bool | `false` | Ingress for OpenCost UI |
+| opencost.ui.ingress.enabled | bool | `true` | Ingress for OpenCost UI |
 | opencost.ui.ingress.hosts | list | See [values.yaml](values.yaml) | A list of host rules used to configure the Ingress |
 | opencost.ui.ingress.ingressClassName | string | `""` | Ingress controller which implements the resource |
 | opencost.ui.ingress.tls | list | `[]` | Ingress TLS configuration |
+| opencost.ui.livenessProbe | object | `{"enabled":true,"failureThreshold":200,"initialDelaySeconds":30,"periodSeconds":10}` | Liveness probe configuration |
+| opencost.ui.livenessProbe.enabled | bool | `true` | Whether probe is enabled |
+| opencost.ui.livenessProbe.failureThreshold | int | `200` | Number of failures for probe to be considered failed |
+| opencost.ui.livenessProbe.initialDelaySeconds | int | `30` | Number of seconds before probe is initiated |
+| opencost.ui.livenessProbe.periodSeconds | int | `10` | Probe frequency in seconds |
+| opencost.ui.readinessProbe | object | `{"enabled":true,"failureThreshold":200,"initialDelaySeconds":30,"periodSeconds":10}` | Readiness probe configuration |
+| opencost.ui.readinessProbe.enabled | bool | `true` | Whether probe is enabled |
+| opencost.ui.readinessProbe.failureThreshold | int | `200` | Number of failures for probe to be considered failed |
+| opencost.ui.readinessProbe.initialDelaySeconds | int | `30` | Number of seconds before probe is initiated |
+| opencost.ui.readinessProbe.periodSeconds | int | `10` | Probe frequency in seconds |
 | opencost.ui.resources.limits | object | `{"cpu":"999m","memory":"1Gi"}` | CPU/Memory resource limits |
 | opencost.ui.resources.requests | object | `{"cpu":"10m","memory":"55Mi"}` | CPU/Memory resource requests |
 | opencost.ui.securityContext | object | `{}` | The security options the container should be run with |

--- a/charts/opencost/templates/deployment.yaml
+++ b/charts/opencost/templates/deployment.yaml
@@ -59,6 +59,35 @@ spec:
           name: {{ include "opencost.fullname" . }}
           resources:
             {{- toYaml .Values.opencost.exporter.resources | nindent 12 }}
+          readinessProbe:
+            httpGet:
+              path: /healthz
+              port: 9003
+            initialDelaySeconds: 30
+            periodSeconds: 10
+            failureThreshold: 200
+          {{- with .Values.opencost.exporter.livenessProbe }}
+          {{- if .enabled }}
+          livenessProbe:
+            httpGet:
+              path: /healthz
+              port: 9003
+            initialDelaySeconds: {{ .initialDelaySeconds }}
+            periodSeconds: {{ .periodSeconds }}
+            failureThreshold: {{ .periodSeconds }}
+          {{- end }}
+          {{- end }}
+          {{- with .Values.opencost.exporter.redinessProbe }}
+          {{- if .enabled }}
+          readinessProbe:
+            httpGet:
+              path: /healthz
+              port: 9003
+            initialDelaySeconds: {{ .initialDelaySeconds }}
+            periodSeconds: {{ .periodSeconds }}
+            failureThreshold: {{ .periodSeconds }}
+          {{- end }}
+          {{- end }}
           ports:
             - containerPort: 9003
               name: http
@@ -110,6 +139,28 @@ spec:
         {{- if .Values.opencost.ui.enabled }}
         - image:  "{{ .Values.opencost.ui.image.registry }}/{{ .Values.opencost.ui.image.repository }}:{{ .Values.opencost.ui.image.tag | default (printf "prod-%s" .Chart.AppVersion) }}"
           name: opencost-ui
+          {{- with .Values.opencost.ui.livenessProbe }}
+          {{- if .enabled }}
+          livenessProbe:
+            httpGet:
+              path: /healthz
+              port: 9090
+            initialDelaySeconds: {{ .initialDelaySeconds }}
+            periodSeconds: {{ .periodSeconds }}
+            failureThreshold: {{ .periodSeconds }}
+          {{- end }}
+          {{- end }}
+          {{- with .Values.opencost.ui.readinessProbe }}
+          {{- if .enabled }}
+          readinessProbe:
+            httpGet:
+              path: /healthz
+              port: 9090
+            initialDelaySeconds: {{ .initialDelaySeconds }}
+            periodSeconds: {{ .periodSeconds }}
+            failureThreshold: {{ .periodSeconds }}
+          {{- end }}
+          {{- end }}
           resources:
             {{- toYaml .Values.opencost.ui.resources | nindent 12 }}
           imagePullPolicy: Always

--- a/charts/opencost/values.yaml
+++ b/charts/opencost/values.yaml
@@ -56,6 +56,26 @@ opencost:
       limits:
         cpu: '999m'
         memory: '1Gi'
+    # -- Liveness probe configuration
+    livenessProbe:
+      # -- Whether probe is enabled
+      enabled: true
+      # -- Number of seconds before probe is initiated
+      initialDelaySeconds: 30
+      # -- Probe frequency in seconds
+      periodSeconds: 10
+      # -- Number of failures for probe to be considered failed
+      failureThreshold: 200
+    # -- Readiness probe configuration
+    readinessProbe:
+      # -- Whether probe is enabled
+      enabled: true
+      # -- Number of seconds before probe is initiated
+      initialDelaySeconds: 30
+      # -- Probe frequency in seconds
+      periodSeconds: 10
+      # -- Number of failures for probe to be considered failed
+      failureThreshold: 200
     # -- The security options the container should be run with
     securityContext: {}
       # capabilities:
@@ -130,6 +150,26 @@ opencost:
       limits:
         cpu: '999m'
         memory: '1Gi'
+    # -- Liveness probe configuration
+    livenessProbe:
+      # -- Whether probe is enabled
+      enabled: true
+      # -- Number of seconds before probe is initiated
+      initialDelaySeconds: 30
+      # -- Probe frequency in seconds
+      periodSeconds: 10
+      # -- Number of failures for probe to be considered failed
+      failureThreshold: 200
+    # -- Readiness probe configuration
+    readinessProbe:
+      # -- Whether probe is enabled
+      enabled: true
+      # -- Number of seconds before probe is initiated
+      initialDelaySeconds: 30
+      # -- Probe frequency in seconds
+      periodSeconds: 10
+      # -- Number of failures for probe to be considered failed
+      failureThreshold: 200
     # -- The security options the container should be run with
     securityContext: {}
       # capabilities:


### PR DESCRIPTION
This adds readiness and liveness probes for both exporter and ui on `/healthz` path.
