### PR TITLE
fix: remove Alto mimir endpoint

### DIFF
--- a/charts/opencost/README.md
+++ b/charts/opencost/README.md
@@ -61,7 +61,7 @@ $ helm install opencost opencost/opencost
 | opencost.nodeSelector | object | `{}` | Node labels for pod assignment |
 | opencost.prometheus.bearer_token | string | `""` | Prometheus Bearer token |
 | opencost.prometheus.external.enabled | bool | `false` | Use external Prometheus (eg. Grafana Cloud) |
-| opencost.prometheus.external.url | string | `"https://mimir-dev-push.infra.alto.com/prometheus"` | External Prometheus url |
+| opencost.prometheus.external.url | string | `"https://prometheus.example.com/prometheus"` | External Prometheus url |
 | opencost.prometheus.internal.enabled | bool | `true` | Use in-cluster Prometheus |
 | opencost.prometheus.internal.namespaceName | string | `"opencost"` | Namespace of in-cluster Prometheus |
 | opencost.prometheus.internal.port | int | `9090` | Service port of in-cluster Prometheus |

--- a/charts/opencost/values.yaml
+++ b/charts/opencost/values.yaml
@@ -149,7 +149,7 @@ opencost:
       # -- Use external Prometheus (eg. Grafana Cloud)
       enabled: false
       # -- External Prometheus url
-      url: 'https://mimir-dev-push.infra.alto.com/prometheus'
+      url: 'https://prometheus.example.com/prometheus'
     internal:
       # -- Use in-cluster Prometheus
       enabled: true


### PR DESCRIPTION
Replace the (probably internal) Alto's Mimir endpoint to something more general.