### PR TITLE
feat: Add network-cost daemonset to chart

### DIFF
--- a/charts/opencost/templates/_helpers.tpl
+++ b/charts/opencost/templates/_helpers.tpl
@@ -88,3 +88,18 @@ Check that either prometheus external or internal is defined
         {{- fail "Only use one of the prometheus setups, internal or external" -}}
 {{- end -}}
 {{- end -}}
+
+{{/*
+Return the appropriate apiVersion for daemonset.
+*/}}
+{{- define "opencost.daemonset.apiVersion" -}}
+{{- if semverCompare "<1.9-0" .Capabilities.KubeVersion.GitVersion -}}
+{{- print "extensions/v1beta1" -}}
+{{- else if semverCompare "^1.9-0" .Capabilities.KubeVersion.GitVersion -}}
+{{- print "apps/v1" -}}
+{{- end -}}
+{{- end -}}
+
+{{- define "opencost.networkCostsName" -}}
+{{- printf "%s-%s" .Release.Name "network-costs" -}}
+{{- end -}}

--- a/charts/opencost/templates/network-costs-config-map-template.yaml
+++ b/charts/opencost/templates/network-costs-config-map-template.yaml
@@ -1,0 +1,16 @@
+{{- if .Values.networkCosts -}}
+{{- if .Values.networkCosts.enabled -}}
+{{- if .Values.networkCosts.config -}}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: network-costs-config
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{ include "opencost.labels" . | nindent 4 }}
+data:
+  config.yaml: |
+{{- toYaml .Values.networkCosts.config | nindent 4 }}
+{{- end -}}
+{{- end -}}
+{{- end -}}

--- a/charts/opencost/templates/network-costs-podmonitor-template.yaml
+++ b/charts/opencost/templates/network-costs-podmonitor-template.yaml
@@ -1,0 +1,32 @@
+{{- if .Values.networkCosts }}
+{{- if .Values.networkCosts.enabled }}
+{{- if .Values.networkCosts.podMonitor }}
+{{- if .Values.networkCosts.podMonitor.enabled }}
+apiVersion: monitoring.coreos.com/v1
+kind: PodMonitor
+metadata:
+  name: {{ include "opencost.networkCostsName" . }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{ include "opencost.labels" . | nindent 4 }}
+    {{- if .Values.networkCosts.podMonitor.additionalLabels }}
+    {{ toYaml .Values.networkCosts.podMonitor.additionalLabels | nindent 4 }}
+    {{- end }}
+spec:
+  podMetricsEndpoints:
+    - port: http-server
+      honorLabels: true
+      interval: 1m
+      scrapeTimeout: 10s
+      path: /metrics
+      scheme: http
+  namespaceSelector:
+    matchNames:
+      - {{ .Release.Namespace }}
+  selector:
+    matchLabels:
+      app: {{ template "opencost.networkCostsName" . }}
+{{- end }}
+{{- end }}
+{{- end }}
+{{- end }}

--- a/charts/opencost/templates/network-costs-psp.template.yaml
+++ b/charts/opencost/templates/network-costs-psp.template.yaml
@@ -1,0 +1,40 @@
+{{- if .Values.networkCosts }}
+{{- if .Values.networkCosts.enabled }}
+{{- if .Capabilities.APIVersions.Has "policy/v1beta1/PodSecurityPolicy" }}
+{{- if .Values.networkCosts.podSecurityPolicy }}
+{{- if .Values.networkCosts.podSecurityPolicy.enabled }}
+apiVersion: {{ include "opencost.podSecurityPolicy.apiVersion" . }}
+kind: PodSecurityPolicy
+metadata:
+    name: {{ template "opencost.fullname" . }}-network-costs
+    labels:
+      {{ include "opencost.labels" . | nindent 6 }}
+spec:
+    privileged: true
+    hostNetwork: true
+    allowedHostPaths:
+    {{- if .Values.networkCosts.hostProc }}
+    - pathPrefix: {{ default "/proc" .Values.networkCosts.hostProc.hostPath }}
+      readOnly: false
+    {{- else }}
+    - pathPrefix: /proc
+      readOnly: false
+    {{- end }}    
+    hostPorts:
+    - min: 1
+      max: 65535
+    seLinux:
+        rule: RunAsAny
+    supplementalGroups:
+        rule: RunAsAny
+    runAsUser:
+        rule: RunAsAny
+    fsGroup:
+        rule: RunAsAny
+    volumes:
+        - '*'
+{{- end }}
+{{- end }}
+{{- end }}
+{{- end }}
+{{- end }}

--- a/charts/opencost/templates/network-costs-role.template.yaml
+++ b/charts/opencost/templates/network-costs-role.template.yaml
@@ -1,0 +1,25 @@
+{{- if .Values.networkCosts }}
+{{- if .Values.networkCosts.enabled }}
+{{- if .Values.networkCosts.podSecurityPolicy }}
+{{- if .Values.networkCosts.podSecurityPolicy.enabled }}
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: {{ template "opencost.fullname" . }}-network-costs
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{ include "opencost.labels" . | nindent 4 }}
+  annotations:
+{{- if .Values.networkCosts.podSecurityPolicy.annotations }}
+{{ toYaml .Values.networkCosts.podSecurityPolicy.annotations | indent 4 }}
+{{- end }}
+rules:
+- apiGroups: ['extensions']
+  resources: ['podsecuritypolicies']
+  verbs: ['use']
+  resourceNames:
+  - {{ template "opencost.fullname" . }}-network-costs
+{{- end }}
+{{- end }}
+{{- end }}
+{{- end }}

--- a/charts/opencost/templates/network-costs-rolebinding.template.yaml
+++ b/charts/opencost/templates/network-costs-rolebinding.template.yaml
@@ -1,0 +1,23 @@
+{{- if .Values.networkCosts }}
+{{- if .Values.networkCosts.enabled }}
+{{- if .Values.networkCosts.podSecurityPolicy }}
+{{- if .Values.networkCosts.podSecurityPolicy.enabled }}
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+    name: {{ template "opencost.fullname" . }}-network-costs
+    namespace: {{ .Release.Namespace }}
+    labels:
+      {{ include "opencost.labels" . | nindent 6 }}
+roleRef:
+    apiGroup: rbac.authorization.k8s.io
+    kind: Role
+    name: {{ template "opencost.fullname" . }}-network-costs
+subjects:
+- kind: ServiceAccount
+  name: {{ template "opencost.serviceAccountName" . }}
+  namespace: {{ .Release.Namespace }}
+{{- end }}
+{{- end }}
+{{- end }}
+{{- end }}

--- a/charts/opencost/templates/network-costs-service-template.yaml
+++ b/charts/opencost/templates/network-costs-service-template.yaml
@@ -1,0 +1,35 @@
+{{- if .Values.networkCosts }}
+{{- if .Values.networkCosts.enabled }}
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ template "opencost.networkCostsName" . }}
+  namespace: {{ .Release.Namespace }}
+{{- if (or .Values.networkCosts.service.annotations .Values.networkCosts.prometheusScrape) }}
+  annotations:
+{{- if .Values.networkCosts.service.annotations }}
+{{ toYaml .Values.networkCosts.service.annotations | indent 4 }}
+{{- end }}
+{{- if .Values.networkCosts.prometheusScrape }}
+    prometheus.io/scrape: "true"
+    prometheus.io/port: {{ (quote .Values.networkCosts.port) | default (quote 3001) }}
+{{- end }}
+{{- end }}
+  labels:
+    {{ unset (include "opencost.labels" . | fromYaml) "app" | toYaml | nindent 4 }}
+    app: {{ template "opencost.networkCostsName" . }}
+{{- if .Values.networkCosts.service.labels }}
+{{ toYaml .Values.networkCosts.service.labels | indent 4 }}
+{{- end }}
+spec:
+  clusterIP: None
+  ports:
+  - name: metrics
+    port: {{ .Values.networkCosts.port | default 3001 }}
+    protocol: TCP
+    targetPort: {{ .Values.networkCosts.port | default 3001 }}
+  selector:
+    app: {{ template "opencost.networkCostsName" . }}
+  type: ClusterIP
+{{- end }}
+{{- end }}

--- a/charts/opencost/templates/network-costs-servicemonitor-template.yaml
+++ b/charts/opencost/templates/network-costs-servicemonitor-template.yaml
@@ -1,0 +1,32 @@
+{{- if and .Values.networkCosts.enabled .Values.networkCosts.serviceMonitor.enabled }}
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: {{ include "opencost.networkCostsName" . }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{ include "opencost.labels" . | nindent 4 }}
+    {{- if .Values.networkCosts.serviceMonitor.additionalLabels }}
+    {{ toYaml .Values.networkCosts.serviceMonitor.additionalLabels | nindent 4 }}
+    {{- end }}
+spec:
+  endpoints:
+    - port: metrics
+      honorLabels: true
+      interval: 1m
+      scrapeTimeout: {{ .Values.networkCosts.serviceMonitor.scrapeTimeout }}
+      path: /metrics
+      scheme: http
+      {{- with .Values.networkCosts.serviceMonitor.metricRelabelings }}
+      metricRelabelings: {{ toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.networkCosts.serviceMonitor.relabelings }}
+      relabelings: {{ toYaml . | nindent 8 }}
+      {{- end }}
+  namespaceSelector:
+    matchNames:
+      - {{ .Release.Namespace }}
+  selector:
+    matchLabels:
+      app: {{ include "opencost.networkCostsName" . }}
+{{- end }}

--- a/charts/opencost/templates/network-costs-template.yaml
+++ b/charts/opencost/templates/network-costs-template.yaml
@@ -1,0 +1,137 @@
+{{- if .Values.networkCosts -}}
+{{- if .Values.networkCosts.enabled -}}
+apiVersion: {{ include "opencost.daemonset.apiVersion" . }}
+kind: DaemonSet
+metadata:
+  name: {{ template "opencost.networkCostsName" . }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "opencost.labels" . | nindent 4 }}
+{{- if .Values.networkCosts.additionalLabels }}
+{{ toYaml .Values.networkCosts.additionalLabels | indent 4 }}
+{{- end }}
+spec:
+  {{- if .Values.networkCosts.updateStrategy }}
+  updateStrategy:
+    {{- toYaml .Values.networkCosts.updateStrategy | nindent 4 }}
+  {{- end }}
+  selector:
+    matchLabels:
+      app: {{ template "opencost.networkCostsName" . }}
+  template:
+    metadata:
+      {{- with .Values.networkCosts.annotations }}
+      annotations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      labels:
+        app: {{ template "opencost.networkCostsName" . }}
+        {{- if .Values.networkCosts.additionalLabels }}
+        {{ toYaml .Values.networkCosts.additionalLabels | nindent 8 }}
+        {{- end }}
+    spec:
+    {{- if .Values.imagePullSecrets }}
+      imagePullSecrets:
+      {{ toYaml .Values.imagePullSecrets | indent 2 }}
+    {{- end }}
+      hostNetwork: true
+      serviceAccountName: {{ template "opencost.serviceAccountName" . }}
+      containers:
+      - name: {{ template "opencost.networkCostsName" . }}
+        image: {{ .Values.networkCosts.image }}
+        {{- if .Values.networkCosts.extraArgs }}
+        args:
+          {{- toYaml .Values.networkCosts.extraArgs | nindent 8 }}
+        {{- end }}
+{{- if .Values.networkCosts.imagePullPolicy }}
+        imagePullPolicy: {{ .Values.networkCosts.imagePullPolicy }}
+{{- else }}
+        imagePullPolicy: Always
+{{- end }}
+{{- if .Values.networkCosts.resources }}
+        resources: {{- toYaml .Values.networkCosts.resources | nindent 10 }}
+{{- end }}
+        env:
+        {{- if .Values.networkCosts.hostProc }}
+        - name: HOST_PROC
+          value: {{ .Values.networkCosts.hostProc.mountPath }}
+        {{- end }}
+        - name: NODE_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: spec.nodeName
+        - name: HOST_PORT
+          value: {{ (quote .Values.networkCosts.port) | default (quote 3001) }}
+        - name: TRAFFIC_LOGGING_ENABLED
+          value: {{ (quote .Values.networkCosts.trafficLogging) | default (quote true) }}
+        {{- if .Values.networkCosts.softMemoryLimit }}
+        - name: GOMEMLIMIT
+          value: {{ .Values.networkCosts.softMemoryLimit }}
+        {{- end }}
+        {{- if .Values.networkCosts.heapMonitor }}
+        {{- if .Values.networkCosts.heapMonitor.enabled }}
+        - name: HEAP_MONITOR_ENABLED
+          value: "true"
+        - name: HEAP_MONITOR_THRESHOLD
+          value: {{ .Values.networkCosts.heapMonitor.threshold }}
+        {{- if .Values.networkCosts.heapMonitor.outFile }}
+        - name: HEAP_MONITOR_OUTPUT
+          value: {{ .Values.networkCosts.heapMonitor.outFile }}
+        {{- end }}
+        {{- end }}
+        {{- end }}
+        volumeMounts:
+        {{- if .Values.networkCosts.hostProc }}
+        - mountPath: {{ .Values.networkCosts.hostProc.mountPath }}
+          name: host-proc
+        {{- else }}
+        - mountPath: /net
+          name: nf-conntrack
+        - mountPath: /netfilter
+          name: netfilter
+        {{- end }}
+        {{- if .Values.networkCosts.config }}
+        - mountPath: /network-costs/config
+          name: network-costs-config
+        {{- end }}
+        securityContext:
+          privileged: true
+        ports:
+        - name: http-server
+          containerPort: {{ .Values.networkCosts.port | default 3001 }}
+          hostPort: {{ .Values.networkCosts.port | default 3001 }}
+{{- if .Values.networkCosts.priorityClassName }}
+      priorityClassName: "{{ .Values.networkCosts.priorityClassName }}"
+{{- end }}
+      {{- with .Values.networkCosts.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 10 }}
+      {{- end }}
+{{- if .Values.networkCosts.tolerations }}
+      tolerations:
+{{ toYaml .Values.networkCosts.tolerations | indent 8 }}
+    {{- end }}
+      {{- with .Values.networkCosts.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      volumes:
+      {{- if .Values.networkCosts.config }}
+      - name: network-costs-config
+        configMap:
+          name: network-costs-config
+      {{- end }}
+      {{- if .Values.networkCosts.hostProc }}
+      - name: host-proc
+        hostPath:
+          path: {{ default "/proc" .Values.networkCosts.hostProc.hostPath }}
+      {{- else }}
+      - name: nf-conntrack
+        hostPath:
+          path: /proc/net
+      - name: netfilter
+        hostPath:
+          path: /proc/sys/net/netfilter
+      {{- end }}
+{{- end }}
+{{- end }}

--- a/charts/opencost/values.yaml
+++ b/charts/opencost/values.yaml
@@ -240,5 +240,133 @@ opencost:
   # -- Assign custom TopologySpreadConstraints rules
   topologySpreadConstraints: []
 
+
+networkCosts:
+  enabled: true
+  podSecurityPolicy:
+    enabled: false
+  image: gcr.io/kubecost1/kubecost-network-costs:v0.16.6
+  imagePullPolicy: Always
+  updateStrategy:
+    type: RollingUpdate
+  # For existing Prometheus Installs, annotates the Service which generates Endpoints for each of the network-costs pods.
+  # The Service is annotated with prometheus.io/scrape: "true" to automatically get picked up by the prometheus config.
+  # NOTE: Setting this option to true and leaving the above extraScrapeConfig "job_name: kubecost-networking" configured will cause the
+  # NOTE: pods to be scraped twice.
+  prometheusScrape: false
+  serviceMonitor:
+    enabled: true
+    scrapeTimeout: 10s
+    additionalLabels: {}
+    metricRelabelings: []
+    relabelings: []
+  # Traffic Logging will enable logging the top 5 destinations for each source
+  # every 30 minutes.
+  trafficLogging: true
+
+  # Port will set both the containerPort and hostPort to this value.
+  # These must be identical due to network-costs being run on hostNetwork
+  port: 3001
+  # this daemonset can use significant resources on large clusters: https://guide.kubecost.com/hc/en-us/articles/4407595973527-Network-Traffic-Cost-Allocation
+  resources:
+    limits: # remove the limits by setting limits: {}
+      cpu: 500m # can be less, will depend on cluster size
+      # memory: it is not recommended to set a memory limit
+    requests:
+     cpu: 50m
+     memory: 20Mi
+  extraArgs: []
+  config:
+    # Configuration for traffic destinations, including specific classification
+    # for IPs and CIDR blocks. This configuration will act as an override to the
+    # automatic classification provided by network-costs.
+    destinations:
+      # In Zone contains a list of address/range that will be
+      # classified as in zone.
+      in-zone:
+        # Loopback Addresses in "IANA IPv4 Special-Purpose Address Registry"
+        - "127.0.0.0/8"
+        # IPv4 Link Local Address Space
+        - "169.254.0.0/16"
+        # Private Address Ranges in RFC-1918
+        - "10.0.0.0/8" # Remove this entry if using Multi-AZ Kubernetes
+        - "172.16.0.0/12"
+        - "192.168.0.0/16"
+
+      # In Region contains a list of address/range that will be
+      # classified as in region. This is synonymous with cross
+      # zone traffic, where the regions between source and destinations
+      # are the same, but the zone is different.
+      in-region: []
+
+      # Cross Region contains a list of address/range that will be
+      # classified as non-internet egress from one region to another.
+      cross-region: []
+
+      # Internet contains a list of address/range that will be
+      # classified as internet traffic. This is synonymous with traffic
+      # that cannot be classified within the cluster.
+      # NOTE: Internet classification filters are executed _after_
+      # NOTE: direct-classification, but before in-zone, in-region,
+      # NOTE: and cross-region.
+      internet: []
+
+      # Direct Classification specifically maps an ip address or range
+      # to a region (required) and/or zone (optional). This classification
+      # takes priority over in-zone, in-region, and cross-region configurations.
+      direct-classification: []
+      # - region: "us-east1"
+      #   zone: "us-east1-c"
+      #   ips:
+      #     - "10.0.0.0/24"
+    services:
+      # google-cloud-services: when set to true, enables labeling traffic metrics with google cloud
+      # service endpoints
+      google-cloud-services: false
+      # amazon-web-services: when set to true, enables labeling traffic metrics with amazon web service
+      # endpoints.
+      amazon-web-services: false
+      # azure-cloud-services: when set to true, enables labeling traffic metrics with azure cloud service
+      # endpoints
+      azure-cloud-services: false
+      # user defined services provide a way to define custom service endpoints which will label traffic metrics
+      # falling within the defined address range.
+      #services:
+      #  - service: "test-service-1"
+      #    ips:
+      #      - "19.1.1.2"
+      #  - service: "test-service-2"
+      #    ips:
+      #      - "15.128.15.2"
+      #      - "20.0.0.0/8"
+
+  ## Node tolerations for server scheduling to nodes with taints
+  ## Ref: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/
+  ##
+  tolerations: []
+  #  - key: "key"
+  #    operator: "Equal|Exists"
+  #    value: "value"
+  #    effect: "NoSchedule|PreferNoSchedule|NoExecute(1.6 only)"
+
+  affinity: {}
+
+  service:
+    annotations: {}
+    labels: {}
+
+  ## PriorityClassName
+  ## Ref: https://kubernetes.io/docs/concepts/configuration/pod-priority-preemption/#priorityclass
+  priorityClassName: ""
+  ## PodMonitor
+  ## Allows scraping of network metrics from a dedicated prometheus operator setup
+  podMonitor:
+    enabled: false
+    additionalLabels: {}
+  additionalLabels: {}
+  nodeSelector: {}
+  annotations: {}
+
+
 # -- A list of volumes to be added to the pod
 extraVolumes: []


### PR DESCRIPTION
# Problem
- Opencost helm chart doesn't have network cost daemonset.
- Opencost have feature calculating network cost, It cannot use this feature without network cost daemonset

# Description
- Add network-costs daemonset.
- It derived almost from https://github.com/kubecost/cost-analyzer-helm-chart.
