### PR TITLE
Add some options for the prometheus secret so you can use an existing secret

### DIFF
--- a/charts/opencost/Chart.yaml
+++ b/charts/opencost/Chart.yaml
@@ -9,7 +9,7 @@ keywords:
   - kubecost
   - opencost
   - monitoring
-version: 1.14.3
+version: 1.14.4
 maintainers:
   - name: mattray
     url: https://mattray.dev

--- a/charts/opencost/templates/_helpers.tpl
+++ b/charts/opencost/templates/_helpers.tpl
@@ -31,6 +31,18 @@ We truncate at 63 chars because some Kubernetes name fields are limited to this 
 {{- end -}}
 
 {{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+*/}}
+{{- define "opencost.prometheus.secretname" -}}
+{{- if .Values.opencost.prometheus.secret_name -}}
+{{- .Values.opencost.prometheus.secret_name -}}
+{{- else -}}
+{{- include "opencost.fullname" . -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
 Common labels
 */}}
 {{- define "opencost.labels" -}}

--- a/charts/opencost/templates/deployment.yaml
+++ b/charts/opencost/templates/deployment.yaml
@@ -110,36 +110,36 @@ spec:
             - name: AWS_ACCESS_KEY_ID
               valueFrom:
                 secretKeyRef:
-                  name: {{ include "opencost.fullname" . }}
+                  name: {{ include "opencost.prometheus.secretname" . }}
                   key: AWS_ACCESS_KEY_ID
             {{- end }}
             {{- if .Values.opencost.exporter.aws.secret_access_key }}
             - name: AWS_SECRET_ACCESS_KEY
               valueFrom:
                 secretKeyRef:
-                  name: {{ include "opencost.fullname" . }}
+                  name: {{ include "opencost.prometheus.secretname" . }}
                   key: AWS_SECRET_ACCESS_KEY
             {{- end }}
             # If username, password or bearer_token are defined, pull from secrets
-            {{- if .Values.opencost.prometheus.username }}
+            {{- if or .Values.opencost.prometheus.username (and .Values.opencost.prometheus.secret_name .Values.opencost.prometheus.username_key) }}
             - name: DB_BASIC_AUTH_USERNAME
               valueFrom:
                 secretKeyRef:
-                  name: {{ include "opencost.fullname" . }}
-                  key: DB_BASIC_AUTH_USERNAME
+                  name: {{ include "opencost.prometheus.secretname" . }}
+                  key: {{ .Values.opencost.prometheus.username_key }}
             {{- end }}
-            {{- if .Values.opencost.prometheus.password }}
+            {{- if or .Values.opencost.prometheus.password (and .Values.opencost.prometheus.secret_name .Values.opencost.prometheus.password_key) }}
             - name: DB_BASIC_AUTH_PW
               valueFrom:
                 secretKeyRef:
-                  name: {{ include "opencost.fullname" . }}
-                  key: DB_BASIC_AUTH_PW
-            {{- else if .Values.opencost.prometheus.bearer_token }}
+                  name: {{ include "opencost.prometheus.secretname" . }}
+                  key: {{ .Values.opencost.prometheus.password_key }}
+            {{- else if or .Values.opencost.prometheus.bearer_token (and .Values.opencost.prometheus.secret_name .Values.opencost.prometheus.bearer_token_key) }}
             - name: DB_BEARER_TOKEN
               valueFrom:
                 secretKeyRef:
-                  name: {{ include "opencost.fullname" . }}
-                  key: DB_BEARER_TOKEN
+                  name: {{ include "opencost.prometheus.secretname" . }}
+                  key: {{ .Values.opencost.prometheus.bearer_token_key }}
             {{- end }}
             {{- if and .Values.opencost.exporter.persistence.enabled .Values.opencost.exporter.csv_path }}
             - name: EXPORT_CSV_FILE

--- a/charts/opencost/templates/secret.yaml
+++ b/charts/opencost/templates/secret.yaml
@@ -4,7 +4,7 @@ kind: Secret
 metadata:
   labels:
     {{- include "opencost.labels" . | nindent 4 }}
-  name: {{ include "opencost.fullname" . }}
+  name: {{ include "opencost.prometheus.secretname" . }}
   namespace: {{ .Release.Namespace }}
   {{- with .Values.secretAnnotations }}
   annotations:
@@ -12,13 +12,13 @@ metadata:
   {{- end }}
 data:
   {{- if .Values.opencost.prometheus.username }}
-  DB_BASIC_AUTH_USERNAME: {{ .Values.opencost.prometheus.username | b64enc | quote }}
+  {{ .Values.opencost.prometheus.username_key }}: {{ .Values.opencost.prometheus.username | b64enc | quote }}
   {{- end }}
   {{- if .Values.opencost.prometheus.password }}
-  DB_BASIC_AUTH_PW: {{ .Values.opencost.prometheus.password | b64enc | quote }}
+  {{ .Values.opencost.prometheus.password_key }}: {{ .Values.opencost.prometheus.password | b64enc | quote }}
   {{- end }}
   {{- if .Values.opencost.prometheus.bearer_token }}
-  DB_BEARER_TOKEN: {{ .Values.opencost.prometheus.bearer_token | b64enc | quote }}
+  {{ .Values.opencost.prometheus.bearer_token_key }}: {{ .Values.opencost.prometheus.bearer_token | b64enc | quote }}
   {{- end }}
   {{- if .Values.opencost.exporter.aws.access_key_id }}
   AWS_ACCESS_KEY_ID: {{ .Values.opencost.exporter.aws.access_key_id | b64enc | quote }}

--- a/charts/opencost/values.yaml
+++ b/charts/opencost/values.yaml
@@ -139,12 +139,19 @@ opencost:
       metricRelabelings: []
 
   prometheus:
+    # -- Secret name that contains credentials for Prometheus
+    secret_name: null
     # -- Prometheus Basic auth username
     username: ""
+    # -- Key in the secret that references the username
+    username_key: DB_BASIC_AUTH_USERNAME
     # -- Prometheus Basic auth password
     password: ""
+    # -- Key in the secret that references the password
+    password_key: DB_BASIC_AUTH_PW
     # -- Prometheus Bearer token
     bearer_token: ""
+    bearer_token_key: DB_BEARER_TOKEN
     external:
       # -- Use external Prometheus (eg. Grafana Cloud)
       enabled: false


### PR DESCRIPTION
Specifically, it allows you to override the secret name, the keys for the username, password, and/or bearer token inside that secret. Just like before, the secret is created values for `username`, `password`, or `bearer_token` are set, and the secret will not be created if those values are not set.

This also updates the deployment to reference the secret with named keys, even if the secret has not been created.

Fixes #75 