### PR TITLE
Remove redundant namespace

### DIFF
--- a/charts/opencost/templates/clusterrole.yaml
+++ b/charts/opencost/templates/clusterrole.yaml
@@ -6,7 +6,6 @@ metadata:
   labels:
     {{- include "opencost.labels" . | nindent 4 }}
   name: {{ include "opencost.fullname" . }}
-  namespace: {{ .Release.Namespace }}
 rules:
   - apiGroups: [""]
     resources:

--- a/charts/opencost/templates/deployment.yaml
+++ b/charts/opencost/templates/deployment.yaml
@@ -5,7 +5,6 @@ metadata:
   labels:
     {{- include "opencost.labels" . | nindent 4 }}
   name: {{ include "opencost.fullname" . }}
-  namespace: {{ .Release.Namespace }}
   {{- if .Values.annotations }}
   annotations: {{ toYaml .Values.annotations | nindent 4 }}
   {{- end }}

--- a/charts/opencost/templates/pvc.yaml
+++ b/charts/opencost/templates/pvc.yaml
@@ -3,7 +3,6 @@ kind: PersistentVolumeClaim
 apiVersion: v1
 metadata:
   name: {{ include "opencost.fullname" . }}-pvc
-  namespace: {{ .Release.Namespace }}
 {{- with .Values.opencost.exporter.persistence.annotations  }}
   annotations:
 {{ toYaml . | indent 4 }}

--- a/charts/opencost/templates/secret.yaml
+++ b/charts/opencost/templates/secret.yaml
@@ -5,7 +5,6 @@ metadata:
   labels:
     {{- include "opencost.labels" . | nindent 4 }}
   name: {{ include "opencost.prometheus.secretname" . }}
-  namespace: {{ .Release.Namespace }}
   {{- with .Values.secretAnnotations }}
   annotations:
     {{- toYaml . | nindent 4 }}

--- a/charts/opencost/templates/service.yaml
+++ b/charts/opencost/templates/service.yaml
@@ -12,7 +12,6 @@ metadata:
     {{- toYaml .Values.service.labels | nindent 4 }}
   {{- end }}
   name: {{ include "opencost.fullname" . }}
-  namespace: {{ .Release.Namespace }}
 spec:
   selector:
     {{- include "opencost.selectorLabels" . | nindent 4 }}

--- a/charts/opencost/templates/serviceaccount.yaml
+++ b/charts/opencost/templates/serviceaccount.yaml
@@ -5,7 +5,6 @@ metadata:
   labels:
     {{- include "opencost.labels" . | nindent 4 }}
   name: {{ template "opencost.serviceAccountName" . }}
-  namespace: {{ .Release.Namespace }}
   {{- if .Values.serviceAccount.annotations }}
   annotations:
   {{- toYaml .Values.serviceAccount.annotations | nindent 4 }}


### PR DESCRIPTION
The PR removes redundant `namespace` from the chart templates.

Helm creates Kubernetes resources (Deployment, ConfigMap, Service, Ingress etc.) in the same namespace where the chart installed, i.e. `.Release.Namespace` is used by default. So there is no reason to set namespace explicitly and it can be removed to keep code cleaner.