### PR TITLE
Fix liveness and readiness probes

### DIFF
--- a/charts/opencost/templates/deployment.yaml
+++ b/charts/opencost/templates/deployment.yaml
@@ -59,13 +59,6 @@ spec:
           name: {{ include "opencost.fullname" . }}
           resources:
             {{- toYaml .Values.opencost.exporter.resources | nindent 12 }}
-          readinessProbe:
-            httpGet:
-              path: /healthz
-              port: 9003
-            initialDelaySeconds: 30
-            periodSeconds: 10
-            failureThreshold: 200
           {{- with .Values.opencost.exporter.livenessProbe }}
           {{- if .enabled }}
           livenessProbe:
@@ -74,10 +67,10 @@ spec:
               port: 9003
             initialDelaySeconds: {{ .initialDelaySeconds }}
             periodSeconds: {{ .periodSeconds }}
-            failureThreshold: {{ .periodSeconds }}
+            failureThreshold: {{ .failureThreshold }}
           {{- end }}
           {{- end }}
-          {{- with .Values.opencost.exporter.redinessProbe }}
+          {{- with .Values.opencost.exporter.readinessProbe }}
           {{- if .enabled }}
           readinessProbe:
             httpGet:
@@ -85,7 +78,7 @@ spec:
               port: 9003
             initialDelaySeconds: {{ .initialDelaySeconds }}
             periodSeconds: {{ .periodSeconds }}
-            failureThreshold: {{ .periodSeconds }}
+            failureThreshold: {{ .failureThreshold }}
           {{- end }}
           {{- end }}
           ports:
@@ -171,7 +164,7 @@ spec:
               port: 9090
             initialDelaySeconds: {{ .initialDelaySeconds }}
             periodSeconds: {{ .periodSeconds }}
-            failureThreshold: {{ .periodSeconds }}
+            failureThreshold: {{ .failureThreshold }}
           {{- end }}
           {{- end }}
           {{- with .Values.opencost.ui.readinessProbe }}
@@ -182,7 +175,7 @@ spec:
               port: 9090
             initialDelaySeconds: {{ .initialDelaySeconds }}
             periodSeconds: {{ .periodSeconds }}
-            failureThreshold: {{ .periodSeconds }}
+            failureThreshold: {{ .failureThreshold }}
           {{- end }}
           {{- end }}
           resources:

--- a/charts/opencost/values.yaml
+++ b/charts/opencost/values.yaml
@@ -75,7 +75,7 @@ opencost:
       # -- Probe frequency in seconds
       periodSeconds: 10
       # -- Number of failures for probe to be considered failed
-      failureThreshold: 200
+      failureThreshold: 3
     # -- Readiness probe configuration
     readinessProbe:
       # -- Whether probe is enabled
@@ -85,7 +85,7 @@ opencost:
       # -- Probe frequency in seconds
       periodSeconds: 10
       # -- Number of failures for probe to be considered failed
-      failureThreshold: 200
+      failureThreshold: 3
     # -- The security options the container should be run with
     securityContext: {}
       # capabilities:
@@ -196,7 +196,7 @@ opencost:
       # -- Probe frequency in seconds
       periodSeconds: 10
       # -- Number of failures for probe to be considered failed
-      failureThreshold: 200
+      failureThreshold: 3
     # -- Readiness probe configuration
     readinessProbe:
       # -- Whether probe is enabled
@@ -206,7 +206,7 @@ opencost:
       # -- Probe frequency in seconds
       periodSeconds: 10
       # -- Number of failures for probe to be considered failed
-      failureThreshold: 200
+      failureThreshold: 3
     # -- The security options the container should be run with
     securityContext: {}
       # capabilities:


### PR DESCRIPTION
The PR fixes liveness and readiness probes:
 - Removed duplicated `readinessProbe` for exporter container
 - Renamed `opencost.exporter.redinessProbe` property to `opencost.exporter.readinessProbe`
 - `failureThreshold` field uses `failureThreshold` property value instead of `periodSeconds`
 - Set `failureThreshold` to default value `3` instead of super high `200`