### PR TITLE
Reformat chart templates

### DIFF
--- a/charts/opencost/Chart.yaml
+++ b/charts/opencost/Chart.yaml
@@ -9,7 +9,7 @@ keywords:
   - kubecost
   - opencost
   - monitoring
-version: 1.15.0
+version: 1.16.0
 maintainers:
   - name: mattray
     url: https://mattray.dev

--- a/charts/opencost/README.md
+++ b/charts/opencost/README.md
@@ -2,7 +2,7 @@
 
 OpenCost and OpenCost UI
 
-![Version: 1.15.0](https://img.shields.io/badge/Version-1.15.0-informational?style=flat-square)
+![Version: 1.16.0](https://img.shields.io/badge/Version-1.16.0-informational?style=flat-square)
 ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
 ![AppVersion: 1.104.0](https://img.shields.io/badge/AppVersion-1.104.0-informational?style=flat-square)
 

--- a/charts/opencost/templates/_helpers.tpl
+++ b/charts/opencost/templates/_helpers.tpl
@@ -3,14 +3,14 @@
 Expand the name of the chart.
 */}}
 {{- define "opencost.name" -}}
-{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" -}}
+  {{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" -}}
 {{- end -}}
 
 {{/*
 Create chart name and version as used by the chart label.
 */}}
 {{- define "opencost.chart" -}}
-{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" -}}
+  {{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" -}}
 {{- end -}}
 
 {{/*
@@ -18,16 +18,16 @@ Create a default fully qualified app name.
 We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
 */}}
 {{- define "opencost.fullname" -}}
-{{- if .Values.fullnameOverride -}}
-{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" -}}
-{{- else -}}
-{{- $name := default .Chart.Name .Values.nameOverride -}}
-{{- if contains $name .Release.Name -}}
-{{- .Release.Name | trunc 63 | trimSuffix "-" -}}
-{{- else -}}
-{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
-{{- end -}}
-{{- end -}}
+  {{- if .Values.fullnameOverride -}}
+    {{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" -}}
+  {{- else -}}
+    {{- $name := default .Chart.Name .Values.nameOverride -}}
+    {{- if contains $name .Release.Name -}}
+      {{- .Release.Name | trunc 63 | trimSuffix "-" -}}
+    {{- else -}}
+      {{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
+    {{- end -}}
+  {{- end -}}
 {{- end -}}
 
 {{/*
@@ -35,11 +35,11 @@ Create a default fully qualified app name.
 We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
 */}}
 {{- define "opencost.prometheus.secretname" -}}
-{{- if .Values.opencost.prometheus.secret_name -}}
-{{- .Values.opencost.prometheus.secret_name -}}
-{{- else -}}
-{{- include "opencost.fullname" . -}}
-{{- end -}}
+  {{- if .Values.opencost.prometheus.secret_name -}}
+    {{- .Values.opencost.prometheus.secret_name -}}
+  {{- else -}}
+    {{- include "opencost.fullname" . -}}
+  {{- end -}}
 {{- end -}}
 
 {{/*
@@ -70,25 +70,25 @@ app.kubernetes.io/instance: {{ .Release.Name }}
 Create the name of the controller service account to use
 */}}
 {{- define "opencost.serviceAccountName" -}}
-{{- if .Values.serviceAccount.create -}}
-    {{ default (include "opencost.fullname" .) .Values.serviceAccount.name }}
-{{- else -}}
-    {{ default "default" .Values.serviceAccount.name }}
-{{- end -}}
+  {{- if .Values.serviceAccount.create -}}
+    {{- default (include "opencost.fullname" .) .Values.serviceAccount.name }}
+  {{- else -}}
+    {{- default "default" .Values.serviceAccount.name }}
+  {{- end -}}
 {{- end -}}
 
 {{/*
 Create the name of the controller service account to use
 */}}
 {{- define "opencost.prometheusServerEndpoint" -}}
-{{- if .Values.opencost.prometheus.external.enabled -}}
+  {{- if .Values.opencost.prometheus.external.enabled -}}
     {{ .Values.opencost.prometheus.external.url }}
-{{- else -}}
+  {{- else -}}
     {{- $host := .Values.opencost.prometheus.internal.serviceName }}
     {{- $ns := .Values.opencost.prometheus.internal.namespaceName }}
     {{- $port := .Values.opencost.prometheus.internal.port | int }}
     {{- printf "http://%s.%s.svc:%d" $host $ns $port -}}
-{{- end -}}
+  {{- end -}}
 {{- end -}}
 
 
@@ -96,7 +96,7 @@ Create the name of the controller service account to use
 Check that either prometheus external or internal is defined
 */}}
 {{- define "isPrometheusConfigValid" -}}
-{{- if and .Values.opencost.prometheus.external.enabled .Values.opencost.prometheus.internal.enabled -}}
-        {{- fail "Only use one of the prometheus setups, internal or external" -}}
-{{- end -}}
+  {{- if and .Values.opencost.prometheus.external.enabled .Values.opencost.prometheus.internal.enabled -}}
+    {{- fail "Only use one of the prometheus setups, internal or external" -}}
+  {{- end -}}
 {{- end -}}

--- a/charts/opencost/templates/clusterrole.yaml
+++ b/charts/opencost/templates/clusterrole.yaml
@@ -3,9 +3,8 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  labels:
-    {{- include "opencost.labels" . | nindent 4 }}
   name: {{ include "opencost.fullname" . }}
+  labels: {{- include "opencost.labels" . | nindent 4 }}
 rules:
   - apiGroups: [""]
     resources:

--- a/charts/opencost/templates/clusterrolebinding.yaml
+++ b/charts/opencost/templates/clusterrolebinding.yaml
@@ -1,13 +1,11 @@
-{{- if .Values.rbac.enabled -}}
+{{- if .Values.rbac.enabled }}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
-  labels:
-    {{- include "opencost.labels" . | nindent 4 }}
   name: {{ include "opencost.fullname" . }}
-  {{- if .Values.annotations }}
-  annotations:
-    {{- toYaml .Values.annotations | nindent 4 }}
+  labels: {{- include "opencost.labels" . | nindent 4 }}
+  {{- with .Values.annotations }}
+  annotations: {{- toYaml . | nindent 4 }}
   {{- end }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -17,4 +15,4 @@ subjects:
   - kind: ServiceAccount
     name: {{ template "opencost.serviceAccountName" . }}
     namespace: {{ .Release.Namespace }}
-{{- end -}}
+{{- end }}

--- a/charts/opencost/templates/deployment.yaml
+++ b/charts/opencost/templates/deployment.yaml
@@ -1,18 +1,16 @@
-{{- include  "isPrometheusConfigValid" . -}}
+{{- include  "isPrometheusConfigValid" . }}
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  labels:
-    {{- include "opencost.labels" . | nindent 4 }}
   name: {{ include "opencost.fullname" . }}
-  {{- if .Values.annotations }}
-  annotations: {{ toYaml .Values.annotations | nindent 4 }}
+  labels: {{- include "opencost.labels" . | nindent 4 }}
+  {{- with .Values.annotations }}
+  annotations: {{- toYaml . | nindent 4 }}
   {{- end }}
 spec:
   replicas: {{ .Values.opencost.exporter.replicas }}
   selector:
-    matchLabels:
-      {{- include "opencost.selectorLabels" . | nindent 6 }}
+    matchLabels: {{- include "opencost.selectorLabels" . | nindent 6 }}
   strategy:
     rollingUpdate:
       maxSurge: 1
@@ -22,72 +20,63 @@ spec:
     metadata:
       labels:
         {{- include "opencost.selectorLabels" . | nindent 8 }}
-        {{- if .Values.podLabels }}
-          {{- toYaml .Values.podLabels | nindent 8 }}
+        {{- with .Values.podLabels }}
+          {{- toYaml . | nindent 8 }}
         {{- end }}
-      {{- if .Values.podAnnotations }}
-      annotations:
-        {{- toYaml .Values.podAnnotations | nindent 8 }}
+      {{- with .Values.podAnnotations }}
+      annotations: {{- toYaml . | nindent 8 }}
       {{- end }}
     spec:
-    {{- if .Values.imagePullSecrets }}
-      imagePullSecrets: {{ toYaml .Values.imagePullSecrets | nindent 8 }}
-    {{- end }}
-      securityContext:
-        {{- toYaml .Values.podSecurityContext | nindent 8 }}
-      serviceAccountName: {{ template "opencost.serviceAccountName" . }}
-      tolerations:
-        {{- toYaml .Values.opencost.tolerations | nindent 8 }}
-      {{- with .Values.opencost.nodeSelector }}
-      nodeSelector:
-        {{- toYaml . | nindent 8 }}
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets: {{- toYaml . | nindent 8 }}
       {{- end }}
       {{- with .Values.priorityClassName }}
       priorityClassName: {{ . }}
       {{- end }}
+      {{- with .Values.podSecurityContext }}
+      securityContext: {{- toYaml . | nindent 8 }}
+      {{- end }}
+      serviceAccountName: {{ template "opencost.serviceAccountName" . }}
+      {{- with .Values.opencost.tolerations }}
+      tolerations: {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.opencost.nodeSelector }}
+      nodeSelector: {{- toYaml . | nindent 8 }}
+      {{- end }}
       {{- with .Values.opencost.affinity }}
-      affinity:
-        {{- toYaml . | nindent 8 }}
+      affinity: {{- toYaml . | nindent 8 }}
       {{- end }}
       {{- with.Values.opencost.topologySpreadConstraints }}
-      topologySpreadConstraints:
-        {{- toYaml . | nindent 8 }}
+      topologySpreadConstraints: {{- toYaml . | nindent 8 }}
       {{- end }}
       containers:
-        - image: "{{ .Values.opencost.exporter.image.registry }}/{{ .Values.opencost.exporter.image.repository }}:{{ .Values.opencost.exporter.image.tag | default (printf "prod-%s" .Chart.AppVersion) }}"
-          name: {{ include "opencost.fullname" . }}
-          resources:
-            {{- toYaml .Values.opencost.exporter.resources | nindent 12 }}
-          {{- with .Values.opencost.exporter.livenessProbe }}
-          {{- if .enabled }}
+        - name: {{ include "opencost.fullname" . }}
+          image: "{{ .Values.opencost.exporter.image.registry }}/{{ .Values.opencost.exporter.image.repository }}:{{ .Values.opencost.exporter.image.tag | default (printf "prod-%s" .Chart.AppVersion) }}"
+          imagePullPolicy: Always
+          ports:
+            - containerPort: 9003
+              name: http
+          resources: {{- toYaml .Values.opencost.exporter.resources | nindent 12 }}
+          {{- if .Values.opencost.exporter.livenessProbe.enabled }}
           livenessProbe:
             httpGet:
               path: /healthz
               port: 9003
-            initialDelaySeconds: {{ .initialDelaySeconds }}
-            periodSeconds: {{ .periodSeconds }}
-            failureThreshold: {{ .failureThreshold }}
+            initialDelaySeconds: {{ .Values.opencost.exporter.livenessProbe.initialDelaySeconds }}
+            periodSeconds: {{ .Values.opencost.exporter.livenessProbe.periodSeconds }}
+            failureThreshold: {{ .Values.opencost.exporter.livenessProbe.failureThreshold }}
           {{- end }}
-          {{- end }}
-          {{- with .Values.opencost.exporter.readinessProbe }}
-          {{- if .enabled }}
+          {{- if .Values.opencost.exporter.readinessProbe.enabled }}
           readinessProbe:
             httpGet:
               path: /healthz
               port: 9003
-            initialDelaySeconds: {{ .initialDelaySeconds }}
-            periodSeconds: {{ .periodSeconds }}
-            failureThreshold: {{ .failureThreshold }}
+            initialDelaySeconds: {{ .Values.opencost.exporter.readinessProbe.initialDelaySeconds }}
+            periodSeconds: {{ .Values.opencost.exporter.readinessProbe.periodSeconds }}
+            failureThreshold: {{ .Values.opencost.exporter.readinessProbe.failureThreshold }}
           {{- end }}
-          {{- end }}
-          ports:
-            - containerPort: 9003
-              name: http
-          securityContext:
-            {{- toYaml .Values.opencost.exporter.securityContext | nindent 12 }}
-          {{- with .Values.opencost.exporter.extraVolumeMounts }}
-          volumeMounts:
-            {{- toYaml . | nindent 12 }}
+          {{- with .Values.opencost.exporter.securityContext }}
+          securityContext: {{- toYaml . | nindent 12 }}
           {{- end }}
           env:
             - name: PROMETHEUS_SERVER_ENDPOINT
@@ -145,57 +134,58 @@ spec:
             - name: {{ $key }}
               value: {{ $value | quote }}
             {{- end }}
-          {{- if .Values.opencost.exporter.persistence.enabled }}
+          {{- if or .Values.opencost.exporter.persistence.enabled .Values.opencost.exporter.extraVolumeMounts }}
           volumeMounts:
+            {{- if .Values.opencost.exporter.persistence.enabled }}
             - mountPath: /mnt/export
               name: opencost-export
               readOnly: false
+            {{- end }}
+            {{- with .Values.opencost.exporter.extraVolumeMounts }}
+              {{- toYaml . | nindent 12 }}
+            {{- end }}
           {{- end }}
-          imagePullPolicy: Always
         {{- if .Values.opencost.ui.enabled }}
-        - image:  "{{ .Values.opencost.ui.image.registry }}/{{ .Values.opencost.ui.image.repository }}:{{ .Values.opencost.ui.image.tag | default (printf "prod-%s" .Chart.AppVersion) }}"
-          name: opencost-ui
-          {{- with .Values.opencost.ui.livenessProbe }}
-          {{- if .enabled }}
-          livenessProbe:
-            httpGet:
-              path: /healthz
-              port: 9090
-            initialDelaySeconds: {{ .initialDelaySeconds }}
-            periodSeconds: {{ .periodSeconds }}
-            failureThreshold: {{ .failureThreshold }}
-          {{- end }}
-          {{- end }}
-          {{- with .Values.opencost.ui.readinessProbe }}
-          {{- if .enabled }}
-          readinessProbe:
-            httpGet:
-              path: /healthz
-              port: 9090
-            initialDelaySeconds: {{ .initialDelaySeconds }}
-            periodSeconds: {{ .periodSeconds }}
-            failureThreshold: {{ .failureThreshold }}
-          {{- end }}
-          {{- end }}
-          resources:
-            {{- toYaml .Values.opencost.ui.resources | nindent 12 }}
+        - name: opencost-ui
+          image:  "{{ .Values.opencost.ui.image.registry }}/{{ .Values.opencost.ui.image.repository }}:{{ .Values.opencost.ui.image.tag | default (printf "prod-%s" .Chart.AppVersion) }}"
           imagePullPolicy: Always
           ports:
             - containerPort: 9090
               name: http-ui
-          securityContext:
-            {{- toYaml .Values.opencost.ui.securityContext | nindent 12 }}
+          resources: {{- toYaml .Values.opencost.ui.resources | nindent 12 }}
+          {{- if .Values.opencost.ui.livenessProbe.enabled }}
+          livenessProbe:
+            httpGet:
+              path: /healthz
+              port: 9090
+            initialDelaySeconds: {{ .Values.opencost.ui.livenessProbe.initialDelaySeconds }}
+            periodSeconds: {{ .Values.opencost.ui.livenessProbe.periodSeconds }}
+            failureThreshold: {{ .Values.opencost.ui.livenessProbe.failureThreshold }}
+          {{- end }}
+          {{- if .Values.opencost.ui.readinessProbe.enabled }}
+          readinessProbe:
+            httpGet:
+              path: /healthz
+              port: 9090
+            initialDelaySeconds: {{ .Values.opencost.ui.readinessProbe.initialDelaySeconds }}
+            periodSeconds: {{ .Values.opencost.ui.readinessProbe.periodSeconds }}
+            failureThreshold: {{ .Values.opencost.ui.readinessProbe.failureThreshold }}
+          {{- end }}
+          {{- with .Values.opencost.ui.securityContext }}
+          securityContext: {{- toYaml . | nindent 12 }}
+          {{- end }}
           {{- with .Values.opencost.ui.extraVolumeMounts }}
-          volumeMounts:
-            {{- toYaml . | nindent 12 }}
+          volumeMounts: {{- toYaml . | nindent 12 }}
           {{- end }}
         {{- end }}
+      {{- if or .Values.opencost.exporter.persistence.enabled .Values.extraVolumes }}
       volumes:
-      {{- if .Values.opencost.exporter.persistence.enabled }}
+        {{- if .Values.opencost.exporter.persistence.enabled }}
         - name: opencost-export
           persistentVolumeClaim:
             claimName: {{ include "opencost.fullname" . }}-pvc
-      {{- end }}
-      {{- with .Values.extraVolumes }}
-        {{- toYaml . | nindent 8 }}
+        {{- end }}
+        {{- with .Values.extraVolumes }}
+          {{- toYaml . | nindent 8 }}
+        {{- end }}
       {{- end }}

--- a/charts/opencost/templates/ingress.yaml
+++ b/charts/opencost/templates/ingress.yaml
@@ -1,33 +1,32 @@
-{{- if and .Values.opencost.ui.enabled .Values.opencost.ui.ingress.enabled -}}
+{{- if and .Values.opencost.ui.enabled .Values.opencost.ui.ingress.enabled }}
 apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   name: {{ include "opencost.fullname" . }}-ingress
-  labels:
-    {{- include "opencost.labels" . | nindent 4 }}
+  labels: {{- include "opencost.labels" . | nindent 4 }}
   {{- with .Values.opencost.ui.ingress.annotations }}
-  annotations: {{ toYaml . | nindent 4 }}
+  annotations: {{- toYaml . | nindent 4 }}
   {{- end }}
 spec:
-{{- if .Values.opencost.ui.ingress.ingressClassName }}
-  ingressClassName: {{ .Values.opencost.ui.ingress.ingressClassName }}
-{{- end }}
-{{- if .Values.opencost.ui.ingress.tls }}
-  tls:
-  {{- range .Values.opencost.ui.ingress.tls }}
-    - hosts:
-      {{- range .hosts }}
-        - {{ . | quote }}
-      {{- end }}
-      secretName: {{ .secretName }}
+  {{- with .Values.opencost.ui.ingress.ingressClassName }}
+  ingressClassName: {{ . }}
   {{- end }}
-{{- end }}
+  {{- if .Values.opencost.ui.ingress.tls }}
+  tls:
+    {{- range .Values.opencost.ui.ingress.tls }}
+    - hosts:
+        {{- range .hosts }}
+        - {{ . | quote }}
+        {{- end }}
+      secretName: {{ .secretName }}
+    {{- end }}
+  {{- end }}
   rules:
-  {{- range .Values.opencost.ui.ingress.hosts }}
+    {{- range .Values.opencost.ui.ingress.hosts }}
     - host: {{ .host | quote }}
       http:
         paths:
-        {{- range .paths }}
+          {{- range .paths }}
           - path: {{ . }}
             pathType: Prefix
             backend:
@@ -35,6 +34,6 @@ spec:
                 name: {{ include "opencost.fullname" $ }}
                 port:
                   name: http-ui
-        {{- end }}
-  {{- end }}
+          {{- end }}
+    {{- end }}
 {{- end }}

--- a/charts/opencost/templates/pvc.yaml
+++ b/charts/opencost/templates/pvc.yaml
@@ -3,12 +3,10 @@ kind: PersistentVolumeClaim
 apiVersion: v1
 metadata:
   name: {{ include "opencost.fullname" . }}-pvc
-{{- with .Values.opencost.exporter.persistence.annotations  }}
-  annotations:
-{{ toYaml . | indent 4 }}
-{{- end }}
-  labels:
-    {{- include "opencost.labels" . | nindent 4 }}
+  labels: {{- include "opencost.labels" . | nindent 4 }}
+  {{- with .Values.opencost.exporter.persistence.annotations  }}
+  annotations: {{- toYaml . | nindent 4 }}
+  {{- end }}
 spec:
   accessModes:
     - {{ .Values.opencost.exporter.persistence.accessMode | quote }}

--- a/charts/opencost/templates/secret.yaml
+++ b/charts/opencost/templates/secret.yaml
@@ -1,13 +1,11 @@
-{{- if or .Values.opencost.prometheus.username .Values.opencost.prometheus.password .Values.opencost.prometheus.bearer_token .Values.opencost.exporter.aws.access_key_id -}}
+{{- if or .Values.opencost.prometheus.username .Values.opencost.prometheus.password .Values.opencost.prometheus.bearer_token .Values.opencost.exporter.aws.access_key_id }}
 apiVersion: v1
 kind: Secret
 metadata:
-  labels:
-    {{- include "opencost.labels" . | nindent 4 }}
   name: {{ include "opencost.prometheus.secretname" . }}
+  labels: {{- include "opencost.labels" . | nindent 4 }}
   {{- with .Values.secretAnnotations }}
-  annotations:
-    {{- toYaml . | nindent 4 }}
+  annotations: {{- toYaml . | nindent 4 }}
   {{- end }}
 data:
   {{- if .Values.opencost.prometheus.username }}

--- a/charts/opencost/templates/service.yaml
+++ b/charts/opencost/templates/service.yaml
@@ -1,20 +1,18 @@
-{{- if .Values.service.enabled -}}
+{{- if .Values.service.enabled }}
 apiVersion: v1
 kind: Service
 metadata:
-  annotations:
-  {{- range $key, $value := .Values.service.annotations }}
-    {{ $key }}: {{ $value | quote }}
-  {{- end }}
+  name: {{ include "opencost.fullname" . }}
   labels:
     {{- include "opencost.labels" . | nindent 4 }}
-  {{- if .Values.service.labels }}
-    {{- toYaml .Values.service.labels | nindent 4 }}
+    {{- with .Values.service.labels }}
+      {{- toYaml . | nindent 4 }}
+    {{- end }}
+  {{- with .Values.service.annotations }}
+  annotations: {{- toYaml . | nindent 4 }}
   {{- end }}
-  name: {{ include "opencost.fullname" . }}
 spec:
-  selector:
-    {{- include "opencost.selectorLabels" . | nindent 4 }}
+  selector: {{- include "opencost.selectorLabels" . | nindent 4 }}
   type: {{ .Values.service.type }}
   ports:
     - name: http
@@ -24,5 +22,5 @@ spec:
     - name: http-ui
       port: 9090
       targetPort: 9090
-    {{- end -}}
-{{- end -}}
+    {{- end }}
+{{- end }}

--- a/charts/opencost/templates/serviceaccount.yaml
+++ b/charts/opencost/templates/serviceaccount.yaml
@@ -1,13 +1,11 @@
-{{- if .Values.serviceAccount.create -}}
+{{- if .Values.serviceAccount.create }}
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  labels:
-    {{- include "opencost.labels" . | nindent 4 }}
   name: {{ template "opencost.serviceAccountName" . }}
-  {{- if .Values.serviceAccount.annotations }}
-  annotations:
-  {{- toYaml .Values.serviceAccount.annotations | nindent 4 }}
+  labels: {{- include "opencost.labels" . | nindent 4 }}
+  {{- with .Values.serviceAccount.annotations }}
+  annotations: {{- toYaml . | nindent 4 }}
   {{- end }}
 automountServiceAccountToken: {{ .Values.serviceAccount.automountServiceAccountToken }}
 {{- end }}

--- a/charts/opencost/templates/servicemonitor.yaml
+++ b/charts/opencost/templates/servicemonitor.yaml
@@ -3,13 +3,13 @@ apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
 metadata:
   name: {{ include "opencost.fullname" . }}
-{{- if .Values.opencost.metrics.serviceMonitor.namespace }}
+  {{- if .Values.opencost.metrics.serviceMonitor.namespace }}
   namespace: {{ .Values.opencost.metrics.serviceMonitor.namespace | quote }}
-{{- end }}
+  {{- end }}
   labels:
     {{- include "opencost.labels" . | nindent 4 }}
     {{- if .Values.opencost.metrics.serviceMonitor.additionalLabels }}
-    {{- toYaml .Values.opencost.metrics.serviceMonitor.additionalLabels | nindent 4 }}
+      {{- toYaml .Values.opencost.metrics.serviceMonitor.additionalLabels | nindent 4 }}
     {{- end }}
 spec:
   endpoints:
@@ -17,18 +17,17 @@ spec:
       scheme: http
       path: /metrics
       interval: {{ .Values.opencost.metrics.serviceMonitor.scrapeInterval }}
-    {{- if .Values.opencost.metrics.serviceMonitor.honorLabels }}
+      {{- if .Values.opencost.metrics.serviceMonitor.honorLabels }}
       honorLabels: true
-    {{- end }}
-    {{- if .Values.opencost.metrics.serviceMonitor.relabelings }}
-      relabelings: {{ toYaml .Values.opencost.metrics.serviceMonitor.relabelings | nindent 8 }}
-    {{- end }}
-    {{- if .Values.opencost.metrics.serviceMonitor.metricRelabelings }}
-      metricRelabelings: {{ toYaml .Values.opencost.metrics.serviceMonitor.metricRelabelings | nindent 8 }}
-    {{- end }}
+      {{- end }}
+      {{- with .Values.opencost.metrics.serviceMonitor.relabelings }}
+      relabelings: {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.opencost.metrics.serviceMonitor.metricRelabelings }}
+      metricRelabelings: {{- toYaml . | nindent 8 }}
+      {{- end }}
   selector:
-    matchLabels:
-      {{- include "opencost.selectorLabels" . | nindent 6 }}
+    matchLabels: {{- include "opencost.selectorLabels" . | nindent 6 }}
   namespaceSelector:
     matchNames:
       - {{ .Release.Namespace }}

--- a/charts/opencost/values.yaml
+++ b/charts/opencost/values.yaml
@@ -22,7 +22,7 @@ secretAnnotations: {}
 # --  Labels to add to the OpenCost Pod
 podLabels: {}
 # --  Pod priority
-priorityClassName: null
+priorityClassName: ~
 
 # -- Holds pod-level security attributes and common container settings
 podSecurityContext: {}
@@ -140,7 +140,7 @@ opencost:
 
   prometheus:
     # -- Secret name that contains credentials for Prometheus
-    secret_name: null
+    secret_name: ~
     # -- Prometheus Basic auth username
     username: ""
     # -- Key in the secret that references the username


### PR DESCRIPTION
The PR reformats chart templates to one style with more readable blocks and indents to improve code readability.
Fixed duplicated `volumeMounts` in main container.

Similar changes: https://github.com/apache/airflow/pull/29917 https://github.com/apache/airflow/pull/29941 https://github.com/apache/airflow/pull/30312 https://github.com/minio/minio/pull/16947 https://github.com/apache/superset/pull/23681