### PR TITLE
chore(github): Generate release notes

### DIFF
--- a/.github/configs/cr.yaml
+++ b/.github/configs/cr.yaml
@@ -1,2 +1,6 @@
 ## Reference: https://github.com/helm/chart-releaser
 index-path: './index.yaml'
+
+# Enable automatic generation of release notes using GitHubs release notes generator.
+# see: https://docs.github.com/en/repositories/releasing-projects-on-github/automatically-generated-release-notes
+generate-release-notes: true


### PR DESCRIPTION
## What

* Enables release note generation via an [option](https://github.com/helm/chart-releaser#create-github-releases-from-helm-chart-packages) provided by chart-releaser. chart-releaser uses GitHub's feature for automatic release note generation ([docs.github.com/en/repositories/releasing-projects-on-github/automatically-generated-release-notes](https://docs.github.com/en/repositories/releasing-projects-on-github/automatically-generated-release-notes)).

## Why

* Current release notes provided in the release are unusable with tools like [Renovate](https://github.com/renovatebot/renovate).
