### PR TITLE
Fix using numerical values in secret.yaml

### DIFF
--- a/charts/opencost/templates/secret.yaml
+++ b/charts/opencost/templates/secret.yaml
@@ -9,10 +9,10 @@ metadata:
   {{- end }}
 data:
   {{- if .Values.opencost.prometheus.username }}
-  {{ .Values.opencost.prometheus.username_key }}: {{ .Values.opencost.prometheus.username | b64enc | quote }}
+  {{ .Values.opencost.prometheus.username_key }}: {{ .Values.opencost.prometheus.username | toString | b64enc | quote }}
   {{- end }}
   {{- if .Values.opencost.prometheus.password }}
-  {{ .Values.opencost.prometheus.password_key }}: {{ .Values.opencost.prometheus.password | b64enc | quote }}
+  {{ .Values.opencost.prometheus.password_key }}: {{ .Values.opencost.prometheus.password | toString | b64enc | quote }}
   {{- end }}
   {{- if .Values.opencost.prometheus.bearer_token }}
   {{ .Values.opencost.prometheus.bearer_token_key }}: {{ .Values.opencost.prometheus.bearer_token | b64enc | quote }}


### PR DESCRIPTION
For numerical values like `1234567` to use as username or password we will face the error:
```
at <b64enc>: wrong type for value; expected string; got int64
```
This PR will fix the problem as stated in https://github.com/helm/helm/issues/1771
