### PR TITLE
Make imagePullPolicy properties configurable

### DIFF
--- a/charts/opencost/Chart.yaml
+++ b/charts/opencost/Chart.yaml
@@ -9,7 +9,7 @@ keywords:
   - kubecost
   - opencost
   - monitoring
-version: 1.16.0
+version: 1.17.0
 maintainers:
   - name: mattray
     url: https://mattray.dev

--- a/charts/opencost/README.md
+++ b/charts/opencost/README.md
@@ -2,7 +2,7 @@
 
 OpenCost and OpenCost UI
 
-![Version: 1.16.0](https://img.shields.io/badge/Version-1.16.0-informational?style=flat-square)
+![Version: 1.17.0](https://img.shields.io/badge/Version-1.17.0-informational?style=flat-square)
 ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
 ![AppVersion: 1.104.0](https://img.shields.io/badge/AppVersion-1.104.0-informational?style=flat-square)
 
@@ -37,12 +37,12 @@ $ helm install opencost opencost/opencost
 | opencost.exporter.defaultClusterId | string | `"default-cluster"` | Default cluster ID to use if cluster_id is not set in Prometheus metrics. |
 | opencost.exporter.extraEnv | object | `{}` | Any extra environment variables you would like to pass on to the pod |
 | opencost.exporter.extraVolumeMounts | list | `[]` | A list of volume mounts to be added to the pod |
+| opencost.exporter.image.pullPolicy | string | `"IfNotPresent"` | Exporter container image pull policy |
 | opencost.exporter.image.registry | string | `"quay.io"` | Exporter container image registry |
 | opencost.exporter.image.repository | string | `"kubecost1/kubecost-cost-model"` | Exporter container image name |
 | opencost.exporter.image.tag | string | `""` (use appVersion in Chart.yaml) | Exporter container image tag |
-| opencost.exporter.livenessProbe | object | `{"enabled":true,"failureThreshold":200,"initialDelaySeconds":30,"periodSeconds":10}` | Liveness probe configuration |
 | opencost.exporter.livenessProbe.enabled | bool | `true` | Whether probe is enabled |
-| opencost.exporter.livenessProbe.failureThreshold | int | `200` | Number of failures for probe to be considered failed |
+| opencost.exporter.livenessProbe.failureThreshold | int | `3` | Number of failures for probe to be considered failed |
 | opencost.exporter.livenessProbe.initialDelaySeconds | int | `30` | Number of seconds before probe is initiated |
 | opencost.exporter.livenessProbe.periodSeconds | int | `10` | Probe frequency in seconds |
 | opencost.exporter.persistence.accessMode | string | `""` | Access mode for persistent volume |
@@ -50,9 +50,8 @@ $ helm install opencost opencost/opencost
 | opencost.exporter.persistence.enabled | bool | `false` |  |
 | opencost.exporter.persistence.size | string | `""` | Size for persistent volume |
 | opencost.exporter.persistence.storageClass | string | `""` | Storage class for persistent volume |
-| opencost.exporter.readinessProbe | object | `{"enabled":true,"failureThreshold":200,"initialDelaySeconds":30,"periodSeconds":10}` | Readiness probe configuration |
 | opencost.exporter.readinessProbe.enabled | bool | `true` | Whether probe is enabled |
-| opencost.exporter.readinessProbe.failureThreshold | int | `200` | Number of failures for probe to be considered failed |
+| opencost.exporter.readinessProbe.failureThreshold | int | `3` | Number of failures for probe to be considered failed |
 | opencost.exporter.readinessProbe.initialDelaySeconds | int | `30` | Number of seconds before probe is initiated |
 | opencost.exporter.readinessProbe.periodSeconds | int | `10` | Probe frequency in seconds |
 | opencost.exporter.replicas | int | `1` | Number of OpenCost replicas to run |
@@ -68,6 +67,7 @@ $ helm install opencost opencost/opencost
 | opencost.metrics.serviceMonitor.scrapeInterval | string | `"30s"` | Interval at which metrics should be scraped |
 | opencost.nodeSelector | object | `{}` | Node labels for pod assignment |
 | opencost.prometheus.bearer_token | string | `""` | Prometheus Bearer token |
+| opencost.prometheus.bearer_token_key | string | `"DB_BEARER_TOKEN"` |  |
 | opencost.prometheus.external.enabled | bool | `false` | Use external Prometheus (eg. Grafana Cloud) |
 | opencost.prometheus.external.url | string | `"https://prometheus.example.com/prometheus"` | External Prometheus url |
 | opencost.prometheus.internal.enabled | bool | `true` | Use in-cluster Prometheus |
@@ -75,11 +75,15 @@ $ helm install opencost opencost/opencost
 | opencost.prometheus.internal.port | int | `9090` | Service port of in-cluster Prometheus |
 | opencost.prometheus.internal.serviceName | string | `"my-prometheus"` | Service name of in-cluster Prometheus |
 | opencost.prometheus.password | string | `""` | Prometheus Basic auth password |
+| opencost.prometheus.password_key | string | `"DB_BASIC_AUTH_PW"` | Key in the secret that references the password |
+| opencost.prometheus.secret_name | string | `nil` | Secret name that contains credentials for Prometheus |
 | opencost.prometheus.username | string | `""` | Prometheus Basic auth username |
+| opencost.prometheus.username_key | string | `"DB_BASIC_AUTH_USERNAME"` | Key in the secret that references the username |
 | opencost.tolerations | list | `[]` | Toleration labels for pod assignment |
 | opencost.topologySpreadConstraints | list | `[]` | Assign custom TopologySpreadConstraints rules |
 | opencost.ui.enabled | bool | `true` | Enable OpenCost UI |
 | opencost.ui.extraVolumeMounts | list | `[]` | A list of volume mounts to be added to the pod |
+| opencost.ui.image.pullPolicy | string | `"IfNotPresent"` | UI container image pull policy |
 | opencost.ui.image.registry | string | `"quay.io"` | UI container image registry |
 | opencost.ui.image.repository | string | `"kubecost1/opencost-ui"` | UI container image name |
 | opencost.ui.image.tag | string | `""` (use appVersion in Chart.yaml) | UI container image tag |
@@ -88,14 +92,12 @@ $ helm install opencost opencost/opencost
 | opencost.ui.ingress.hosts | list | See [values.yaml](values.yaml) | A list of host rules used to configure the Ingress |
 | opencost.ui.ingress.ingressClassName | string | `""` | Ingress controller which implements the resource |
 | opencost.ui.ingress.tls | list | `[]` | Ingress TLS configuration |
-| opencost.ui.livenessProbe | object | `{"enabled":true,"failureThreshold":200,"initialDelaySeconds":30,"periodSeconds":10}` | Liveness probe configuration |
 | opencost.ui.livenessProbe.enabled | bool | `true` | Whether probe is enabled |
-| opencost.ui.livenessProbe.failureThreshold | int | `200` | Number of failures for probe to be considered failed |
+| opencost.ui.livenessProbe.failureThreshold | int | `3` | Number of failures for probe to be considered failed |
 | opencost.ui.livenessProbe.initialDelaySeconds | int | `30` | Number of seconds before probe is initiated |
 | opencost.ui.livenessProbe.periodSeconds | int | `10` | Probe frequency in seconds |
-| opencost.ui.readinessProbe | object | `{"enabled":true,"failureThreshold":200,"initialDelaySeconds":30,"periodSeconds":10}` | Readiness probe configuration |
 | opencost.ui.readinessProbe.enabled | bool | `true` | Whether probe is enabled |
-| opencost.ui.readinessProbe.failureThreshold | int | `200` | Number of failures for probe to be considered failed |
+| opencost.ui.readinessProbe.failureThreshold | int | `3` | Number of failures for probe to be considered failed |
 | opencost.ui.readinessProbe.initialDelaySeconds | int | `30` | Number of seconds before probe is initiated |
 | opencost.ui.readinessProbe.periodSeconds | int | `10` | Probe frequency in seconds |
 | opencost.ui.resources.limits | object | `{"cpu":"999m","memory":"1Gi"}` | CPU/Memory resource limits |

--- a/charts/opencost/templates/clusterrole.yaml
+++ b/charts/opencost/templates/clusterrole.yaml
@@ -77,4 +77,3 @@ rules:
       - get
       - list
       - watch
-

--- a/charts/opencost/templates/deployment.yaml
+++ b/charts/opencost/templates/deployment.yaml
@@ -52,7 +52,7 @@ spec:
       containers:
         - name: {{ include "opencost.fullname" . }}
           image: "{{ .Values.opencost.exporter.image.registry }}/{{ .Values.opencost.exporter.image.repository }}:{{ .Values.opencost.exporter.image.tag | default (printf "prod-%s" .Chart.AppVersion) }}"
-          imagePullPolicy: Always
+          imagePullPolicy: {{ .Values.opencost.exporter.image.pullPolicy }}
           ports:
             - containerPort: 9003
               name: http
@@ -148,7 +148,7 @@ spec:
         {{- if .Values.opencost.ui.enabled }}
         - name: opencost-ui
           image:  "{{ .Values.opencost.ui.image.registry }}/{{ .Values.opencost.ui.image.repository }}:{{ .Values.opencost.ui.image.tag | default (printf "prod-%s" .Chart.AppVersion) }}"
-          imagePullPolicy: Always
+          imagePullPolicy: {{ .Values.opencost.ui.image.pullPolicy }}
           ports:
             - containerPort: 9090
               name: http-ui

--- a/charts/opencost/values.yaml
+++ b/charts/opencost/values.yaml
@@ -55,6 +55,8 @@ opencost:
       # -- Exporter container image tag
       # @default -- `""` (use appVersion in Chart.yaml)
       tag: ""
+      # -- Exporter container image pull policy
+      pullPolicy: IfNotPresent
     # -- Number of OpenCost replicas to run
     replicas: 1
     resources:
@@ -66,7 +68,7 @@ opencost:
       limits:
         cpu: '999m'
         memory: '1Gi'
-    # -- Liveness probe configuration
+    # Liveness probe configuration
     livenessProbe:
       # -- Whether probe is enabled
       enabled: true
@@ -76,7 +78,7 @@ opencost:
       periodSeconds: 10
       # -- Number of failures for probe to be considered failed
       failureThreshold: 3
-    # -- Readiness probe configuration
+    # Readiness probe configuration
     readinessProbe:
       # -- Whether probe is enabled
       enabled: true
@@ -178,6 +180,8 @@ opencost:
       # -- UI container image tag
       # @default -- `""` (use appVersion in Chart.yaml)
       tag: ""
+      # -- UI container image pull policy
+      pullPolicy: IfNotPresent
     resources:
       # -- CPU/Memory resource requests
       requests:
@@ -187,7 +191,7 @@ opencost:
       limits:
         cpu: '999m'
         memory: '1Gi'
-    # -- Liveness probe configuration
+    # Liveness probe configuration
     livenessProbe:
       # -- Whether probe is enabled
       enabled: true
@@ -197,7 +201,7 @@ opencost:
       periodSeconds: 10
       # -- Number of failures for probe to be considered failed
       failureThreshold: 3
-    # -- Readiness probe configuration
+    # Readiness probe configuration
     readinessProbe:
       # -- Whether probe is enabled
       enabled: true


### PR DESCRIPTION
The PR makes `imagePullPolicy` properties configurable with default value `IfNotPresent` for `exporter` and `ui` containers.
The PR includes minor README changes rendered by `helm-docs` run.
