### PR TITLE
Pass CLOUD_PROVIDER_API_KEY environment variable from secret

### DIFF
--- a/charts/opencost/templates/_helpers.tpl
+++ b/charts/opencost/templates/_helpers.tpl
@@ -43,6 +43,18 @@ We truncate at 63 chars because some Kubernetes name fields are limited to this 
 {{- end -}}
 
 {{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+*/}}
+{{- define "opencost.exporter.secretname" -}}
+  {{- if .Values.opencost.exporter.secret_name -}}
+    {{- .Values.opencost.exporter.secret_name -}}
+  {{- else -}}
+    {{- include "opencost.fullname" . -}}
+  {{- end -}}
+{{- end -}}
+
+{{/*
 Common labels
 */}}
 {{- define "opencost.labels" -}}

--- a/charts/opencost/templates/deployment.yaml
+++ b/charts/opencost/templates/deployment.yaml
@@ -83,7 +83,10 @@ spec:
               value: {{ include "opencost.prometheusServerEndpoint" . | quote }}
             {{- if .Values.opencost.exporter.cloudProviderApiKey }}
             - name: CLOUD_PROVIDER_API_KEY
-              value: {{ .Values.opencost.exporter.cloudProviderApiKey | quote }}
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "opencost.prometheus.secretname" . }}
+                    key: CLOUD_PROVIDER_API_KEY
             {{- end }}
             - name: CLUSTER_ID
               value: {{ .Values.opencost.exporter.defaultClusterId | quote }}

--- a/charts/opencost/templates/secret.yaml
+++ b/charts/opencost/templates/secret.yaml
@@ -17,6 +17,9 @@ data:
   {{- if .Values.opencost.prometheus.bearer_token }}
   {{ .Values.opencost.prometheus.bearer_token_key }}: {{ .Values.opencost.prometheus.bearer_token | b64enc | quote }}
   {{- end }}
+  {{- if .Values.opencost.exporter.cloudProviderApiKey }}
+  CLOUD_PROVIDER_API_KEY: {{ .Values.opencost.exporter.cloudProviderApiKey | b64enc | quote }}
+  {{- end }}
   {{- if .Values.opencost.exporter.aws.access_key_id }}
   AWS_ACCESS_KEY_ID: {{ .Values.opencost.exporter.aws.access_key_id | b64enc | quote }}
   {{- end }}

--- a/charts/opencost/values.yaml
+++ b/charts/opencost/values.yaml
@@ -90,6 +90,8 @@ opencost:
       periodSeconds: 10
       # -- Number of failures for probe to be considered failed
       failureThreshold: 3
+    # -- Secret name that contains credentials for exporter
+    secret_name: ~
     # -- The security options the container should be run with
     securityContext: {}
       # capabilities:


### PR DESCRIPTION
`CLOUD_PROVIDER_API_KEY` can only be defined in values.yaml file.

Passing it as a secret, it allows a third operator to write a secret (e.g.: vault secret injector or other), store it as Kubernetes secret and then be read by opencost as a environment variable.

The current change won't break the functionality, so it is a refactoring.