### PR TITLE
feat: Support thanos integration

### DIFF
--- a/charts/opencost/Chart.yaml
+++ b/charts/opencost/Chart.yaml
@@ -9,7 +9,7 @@ keywords:
   - kubecost
   - opencost
   - monitoring
-version: 1.18.0
+version: 1.19.0
 maintainers:
   - name: mattray
     url: https://mattray.dev

--- a/charts/opencost/templates/_helpers.tpl
+++ b/charts/opencost/templates/_helpers.tpl
@@ -92,11 +92,27 @@ Create the name of the controller service account to use
 {{- end -}}
 
 
+{{- define "opencost.thanosServerEndpoint" -}}
+  {{- if .Values.opencost.prometheus.thanos.external.enabled -}}
+    {{ .Values.opencost.prometheus.thanos.external.url }}
+  {{- else -}}
+    {{- $host := .Values.opencost.prometheus.thanos.internal.serviceName }}
+    {{- $ns := .Values.opencost.prometheus.thanos.internal.namespaceName }}
+    {{- $port := .Values.opencost.prometheus.thanos.internal.port | int }}
+    {{- printf "http://%s.%s.svc:%d" $host $ns $port -}}
+  {{- end -}}
+{{- end -}}
+
 {{/*
 Check that either prometheus external or internal is defined
 */}}
 {{- define "isPrometheusConfigValid" -}}
   {{- if and .Values.opencost.prometheus.external.enabled .Values.opencost.prometheus.internal.enabled -}}
     {{- fail "Only use one of the prometheus setups, internal or external" -}}
+  {{- end -}}
+  {{- if .Values.opencost.prometheus.thanos.enabled -}}
+    {{- if and .Values.opencost.prometheus.thanos.external.enabled .Values.opencost.prometheus.thanos.internal.enabled -}}
+      {{- fail "Only use one of the thanos setups, internal or external" -}}
+    {{- end -}}
   {{- end -}}
 {{- end -}}

--- a/charts/opencost/templates/deployment.yaml
+++ b/charts/opencost/templates/deployment.yaml
@@ -125,7 +125,21 @@ spec:
             {{- if and .Values.opencost.exporter.persistence.enabled .Values.opencost.exporter.csv_path }}
             - name: EXPORT_CSV_FILE
               value: {{ .Values.opencost.exporter.csv_path | quote }}
-            {{- end}}
+            {{- end }}
+            {{- if .Values.opencost.prometheus.thanos.enabled }}
+            - name: THANOS_ENABLED
+              value: 'true'
+            - name: THANOS_QUERY_URL
+              value: {{ include "opencost.thanosServerEndpoint" . | quote }}
+            {{- end }}
+            {{- if .Values.opencost.prometheus.thanos.queryOffset }}
+            - name: THANOS_QUERY_OFFSET
+              value: {{ .Values.opencost.prometheus.thanos.queryOffset | quote }}
+            {{- end }}
+            {{- if .Values.opencost.prometheus.thanos.maxSourceResolution }}
+            - name: THANOS_MAX_SOURCE_RESOLUTION
+              value: {{ .Values.opencost.prometheus.thanos.maxSourceResolution | quote }}
+            {{- end }}
             {{- with .Values.opencost.exporter.env }}
               {{- toYaml . | nindent 12 }}
             {{- end }}

--- a/charts/opencost/values.yaml
+++ b/charts/opencost/values.yaml
@@ -170,6 +170,19 @@ opencost:
       namespaceName: opencost
       # -- Service port of in-cluster Prometheus
       port: 9090
+    
+    thanos:
+      enabled: true
+      queryOffset: ''
+      maxSourceResolution: ''
+      internal:
+        enabled: true
+        serviceName: my-thanos-query
+        namespaceName: opencost
+        port: 10901
+      external:
+        enabled: false
+        url: 'https://thanos-query.example.com/thanos'
 
   ui:
     # -- Enable OpenCost UI

--- a/charts/opencost/values.yaml
+++ b/charts/opencost/values.yaml
@@ -172,7 +172,7 @@ opencost:
       port: 9090
     
     thanos:
-      enabled: true
+      enabled: false
       queryOffset: ''
       maxSourceResolution: ''
       internal:

--- a/charts/opencost/values.yaml
+++ b/charts/opencost/values.yaml
@@ -170,7 +170,6 @@ opencost:
       namespaceName: opencost
       # -- Service port of in-cluster Prometheus
       port: 9090
-    
     thanos:
       enabled: false
       queryOffset: ''


### PR DESCRIPTION
# Description
- Add thanos support 
  - https://github.com/opencost/opencost/blob/develop/pkg/env/costmodelenv.go#L49-L52
- It doesn't install thanos. Thanos has to be installed first.
