### PR TITLE
increased readiness and liveness probe delay to 120

### DIFF
--- a/charts/opencost/Chart.yaml
+++ b/charts/opencost/Chart.yaml
@@ -9,7 +9,7 @@ keywords:
   - kubecost
   - opencost
   - monitoring
-version: 1.19.2
+version: 1.19.3
 maintainers:
   - name: mattray
     url: https://mattray.dev

--- a/charts/opencost/README.md
+++ b/charts/opencost/README.md
@@ -2,7 +2,7 @@
 
 OpenCost and OpenCost UI
 
-![Version: 1.19.2](https://img.shields.io/badge/Version-1.19.1-informational?style=flat-square)
+![Version: 1.19.3](https://img.shields.io/badge/Version-1.19.3-informational?style=flat-square)
 ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
 ![AppVersion: 1.105.2](https://img.shields.io/badge/AppVersion-1.105.2-informational?style=flat-square)
 

--- a/charts/opencost/values.yaml
+++ b/charts/opencost/values.yaml
@@ -78,7 +78,7 @@ opencost:
       # -- Whether probe is enabled
       enabled: true
       # -- Number of seconds before probe is initiated
-      initialDelaySeconds: 30
+      initialDelaySeconds: 120
       # -- Probe frequency in seconds
       periodSeconds: 10
       # -- Number of failures for probe to be considered failed
@@ -88,7 +88,7 @@ opencost:
       # -- Whether probe is enabled
       enabled: true
       # -- Number of seconds before probe is initiated
-      initialDelaySeconds: 30
+      initialDelaySeconds: 120
       # -- Probe frequency in seconds
       periodSeconds: 10
       # -- Number of failures for probe to be considered failed


### PR DESCRIPTION
Increased default values `initialDelaySeconds` for `livenessProbe` and `readinessProbe`. Related to #73 