### PR TITLE
feat: AWS Managed Prometheus sigv4 integration

### DIFF
--- a/charts/opencost/templates/deployment.yaml
+++ b/charts/opencost/templates/deployment.yaml
@@ -191,6 +191,39 @@ spec:
           volumeMounts: {{- toYaml . | nindent 12 }}
           {{- end }}
         {{- end }}
+        {{- if and .Values.opencost.prometheus.amp.enabled .Values.opencost.sigV4Proxy }}
+        - name: sigv4proxy
+          image: {{ .Values.opencost.sigV4Proxy.image }}
+          imagePullPolicy: {{ .Values.opencost.sigV4Proxy.imagePullPolicy }}
+          args:
+          - --name
+          - {{ .Values.opencost.sigV4Proxy.name }}
+          - --region
+          - {{ .Values.opencost.sigV4Proxy.region }}
+          - --host
+          - {{ .Values.opencost.sigV4Proxy.host }}
+          {{- if .Values.opencost.sigV4Proxy.role_arn }}
+          - --role-arn
+          - {{ .Values.opencost.sigV4Proxy.role_arn }}
+          {{- end }}
+          - --port
+          - :{{ .Values.opencost.sigV4Proxy.port }}
+          ports:
+          - name: aws-sigv4-proxy
+            containerPort: {{ .Values.opencost.sigV4Proxy.port | int }}
+          {{- with .Values.opencost.sigV4Proxy.extraEnv }}
+          env:
+          {{- toYaml . | nindent 10 }}
+          {{- end }}
+          {{- with .Values.opencost.sigV4Proxy.resources }}
+          resources:
+          {{- toYaml . | nindent 12 }}
+          {{- end }}
+          {{- with .Values.opencost.sigV4Proxy.securityContext }}
+          securityContext:
+          {{- toYaml . | nindent 12 }}
+          {{- end }}
+        {{- end }}
       {{- if or .Values.opencost.exporter.persistence.enabled .Values.extraVolumes }}
       volumes:
         {{- if .Values.opencost.exporter.persistence.enabled }}

--- a/charts/opencost/values.yaml
+++ b/charts/opencost/values.yaml
@@ -175,6 +175,11 @@ opencost:
       namespaceName: opencost
       # -- Service port of in-cluster Prometheus
       port: 9090
+    amp:
+      # -- Use Amazon Managed Service for Prometheus (AMP)
+      enabled: false  # If true, opencost will be configured to remote_write and query from Amazon Managed Service for Prometheus.
+      # -- Workspace ID for AMP
+      workspaceId: ""
     thanos:
       enabled: false
       queryOffset: ''
@@ -261,6 +266,35 @@ opencost:
         #  - secretName: chart-example-tls
         #    hosts:
         #      - chart-example.local
+
+  sigV4Proxy:
+    image: public.ecr.aws/aws-observability/aws-sigv4-proxy:latest
+    imagePullPolicy: IfNotPresent
+    name: aps
+    port: 8005
+    region: us-west-2 # The AWS region
+    host: aps-workspaces.us-west-2.amazonaws.com # The hostname for AMP service.
+    # role_arn: arn:aws:iam::<account>:role/role-name # The AWS IAM role to assume.
+    extraEnv: # Pass extra env variables to sigV4Proxy
+    # - name: AWS_ACCESS_KEY_ID
+    #   value: <access_key>
+    # - name: AWS_SECRET_ACCESS_KEY
+    #   value: <secret_key>
+    resources: {}
+      # limits:
+      #   cpu: 200m
+      #   memory: 500Mi
+      # requests:
+      #   cpu: 20m
+      #   memory: 32Mi
+    securityContext: {}
+      # capabilities:
+      #   drop:
+      #   - ALL
+      # readOnlyRootFilesystem: true
+      # runAsNonRoot: true
+      # runAsUser: 65534
+
   # -- Toleration labels for pod assignment
   tolerations: []
   # -- Node labels for pod assignment


### PR DESCRIPTION
closes https://github.com/opencost/opencost/issues/1906

```bash
helm template opencost . --set opencost.prometheus.amp.enabled=true --set opencost.prometheus.internal.enabled=false --set opencost.prometheus.amp.workspaceId=my-workspace-id
```

result:
```yaml
---
# Source: opencost/templates/serviceaccount.yaml
apiVersion: v1
kind: ServiceAccount
metadata:
  name: opencost
  labels:
    helm.sh/chart: opencost-1.19.3
    app.kubernetes.io/name: opencost
    app.kubernetes.io/instance: opencost
    app.kubernetes.io/version: "1.105.2"
    app.kubernetes.io/part-of: opencost
    app.kubernetes.io/managed-by: Helm
automountServiceAccountToken: true
---
# Source: opencost/templates/clusterrole.yaml
# Cluster role giving opencost to get, list, watch required resources
# No write permissions are required
apiVersion: rbac.authorization.k8s.io/v1
kind: ClusterRole
metadata:
  name: opencost
  labels:
    helm.sh/chart: opencost-1.19.3
    app.kubernetes.io/name: opencost
    app.kubernetes.io/instance: opencost
    app.kubernetes.io/version: "1.105.2"
    app.kubernetes.io/part-of: opencost
    app.kubernetes.io/managed-by: Helm
rules:
  - apiGroups: [""]
    resources:
      - configmaps
      - deployments
      - nodes
      - pods
      - services
      - resourcequotas
      - replicationcontrollers
      - limitranges
      - persistentvolumeclaims
      - persistentvolumes
      - namespaces
      - endpoints
    verbs:
      - get
      - list
      - watch
  - apiGroups:
      - extensions
    resources:
      - daemonsets
      - deployments
      - replicasets
    verbs:
      - get
      - list
      - watch
  - apiGroups:
      - apps
    resources:
      - statefulsets
      - deployments
      - daemonsets
      - replicasets
    verbs:
      - list
      - watch
  - apiGroups:
      - batch
    resources:
      - cronjobs
      - jobs
    verbs:
      - get
      - list
      - watch
  - apiGroups:
      - autoscaling
    resources:
      - horizontalpodautoscalers
    verbs:
      - get
      - list
      - watch
  - apiGroups:
      - policy
    resources:
      - poddisruptionbudgets
    verbs:
      - get
      - list
      - watch
  - apiGroups:
      - storage.k8s.io
    resources:
      - storageclasses
    verbs:
      - get
      - list
      - watch
---
# Source: opencost/templates/clusterrolebinding.yaml
apiVersion: rbac.authorization.k8s.io/v1
kind: ClusterRoleBinding
metadata:
  name: opencost
  labels:
    helm.sh/chart: opencost-1.19.3
    app.kubernetes.io/name: opencost
    app.kubernetes.io/instance: opencost
    app.kubernetes.io/version: "1.105.2"
    app.kubernetes.io/part-of: opencost
    app.kubernetes.io/managed-by: Helm
roleRef:
  apiGroup: rbac.authorization.k8s.io
  kind: ClusterRole
  name: opencost
subjects:
  - kind: ServiceAccount
    name: opencost
    namespace: default
---
# Source: opencost/templates/service.yaml
apiVersion: v1
kind: Service
metadata:
  name: opencost
  labels:
    helm.sh/chart: opencost-1.19.3
    app.kubernetes.io/name: opencost
    app.kubernetes.io/instance: opencost
    app.kubernetes.io/version: "1.105.2"
    app.kubernetes.io/part-of: opencost
    app.kubernetes.io/managed-by: Helm
spec:
  selector:
    app.kubernetes.io/name: opencost
    app.kubernetes.io/instance: opencost
  type: ClusterIP
  ports:
    - name: http
      port: 9003
      targetPort: 9003
    - name: http-ui
      port: 9090
      targetPort: 9090
---
# Source: opencost/templates/deployment.yaml
apiVersion: apps/v1
kind: Deployment
metadata:
  name: opencost
  labels:
    helm.sh/chart: opencost-1.19.3
    app.kubernetes.io/name: opencost
    app.kubernetes.io/instance: opencost
    app.kubernetes.io/version: "1.105.2"
    app.kubernetes.io/part-of: opencost
    app.kubernetes.io/managed-by: Helm
spec:
  replicas: 1
  selector:
    matchLabels:
      app.kubernetes.io/name: opencost
      app.kubernetes.io/instance: opencost
  strategy:
    rollingUpdate:
      maxSurge: 1
      maxUnavailable: 1
    type: RollingUpdate
  template:
    metadata:
      labels:
        app.kubernetes.io/name: opencost
        app.kubernetes.io/instance: opencost
    spec:
      serviceAccountName: opencost
      containers:
        - name: opencost
          image: "quay.io/kubecost1/kubecost-cost-model:prod-1.105.2"
          imagePullPolicy: IfNotPresent
          ports:
            - containerPort: 9003
              name: http
          resources:
            limits:
              cpu: 999m
              memory: 1Gi
            requests:
              cpu: 10m
              memory: 55Mi
          livenessProbe:
            httpGet:
              path: /healthz
              port: 9003
            initialDelaySeconds: 120
            periodSeconds: 10
            failureThreshold: 3
          readinessProbe:
            httpGet:
              path: /healthz
              port: 9003
            initialDelaySeconds: 120
            periodSeconds: 10
            failureThreshold: 3
          env:
            - name: PROMETHEUS_SERVER_ENDPOINT
              value: "http://localhost:8005/workspaces/my-workspace-id"
            - name: CLUSTER_ID
              value: "default-cluster"
            # If username, password or bearer_token are defined, pull from secrets
        - name: opencost-ui
          image:  "quay.io/kubecost1/opencost-ui:prod-1.105.2"
          imagePullPolicy: IfNotPresent
          ports:
            - containerPort: 9090
              name: http-ui
          resources:
            limits:
              cpu: 999m
              memory: 1Gi
            requests:
              cpu: 10m
              memory: 55Mi
          livenessProbe:
            httpGet:
              path: /healthz
              port: 9090
            initialDelaySeconds: 30
            periodSeconds: 10
            failureThreshold: 3
          readinessProbe:
            httpGet:
              path: /healthz
              port: 9090
            initialDelaySeconds: 30
            periodSeconds: 10
            failureThreshold: 3
        - name: sigv4proxy
          image: public.ecr.aws/aws-observability/aws-sigv4-proxy:latest
          imagePullPolicy: IfNotPresent
          args:
          - --name
          - aps
          - --region
          - us-west-2
          - --host
          - aps-workspaces.us-west-2.amazonaws.com
          - --port
          - :8005
          ports:
          - name: aws-sigv4-proxy
            containerPort: 8005
```

In particular take note of:
```
            - name: PROMETHEUS_SERVER_ENDPOINT
              value: "http://localhost:8005/workspaces/my-workspace-id"
```

And the sidecar container `sigv4proxy`