### PR TITLE
Make deployment updateStrategy variable.

### DIFF
--- a/charts/opencost/Chart.yaml
+++ b/charts/opencost/Chart.yaml
@@ -9,7 +9,7 @@ keywords:
   - kubecost
   - opencost
   - monitoring
-version: 1.20.3
+version: 1.21.0
 maintainers:
   - name: mattray
     url: https://mattray.dev

--- a/charts/opencost/templates/deployment.yaml
+++ b/charts/opencost/templates/deployment.yaml
@@ -11,11 +11,7 @@ spec:
   replicas: {{ .Values.opencost.exporter.replicas }}
   selector:
     matchLabels: {{- include "opencost.selectorLabels" . | nindent 6 }}
-  strategy:
-    rollingUpdate:
-      maxSurge: 1
-      maxUnavailable: 1
-    type: RollingUpdate
+  strategy: {{ toYaml .Values.updateStrategy | nindent 4 }}
   template:
     metadata:
       labels:

--- a/charts/opencost/values.yaml
+++ b/charts/opencost/values.yaml
@@ -18,6 +18,12 @@ serviceAccount:
   # -- Whether pods running as this service account should have an API token automatically mounted
   automountServiceAccountToken: true
 
+# --  Strategy to be used for the Deployment
+updateStrategy:
+  rollingUpdate:
+    maxSurge: 1
+    maxUnavailable: 1
+  type: RollingUpdate
 # --  Annotations to add to the all the resources
 annotations: {}
 # --  Annotations to add to the OpenCost Pod


### PR DESCRIPTION
There are scenarios where the pod can get scraped twice by the ServiceMonitor. This will leave duplicate series in prometheus that may lead to many-to-many queries causing broken grafana dashboards.

With this change updateStrategy can be changed to Recreate for those cases.

Example error message
> Status: 500. Message: execution: found duplicate series for the match group {instance_type="m5a.8xlarge", node="ip-10-1-120-2.ec2.internal"} on the right hand-side of the operation: [{container="opencost", endpoint="http", instance="10.1.116.161:9003", instance_type="m5a.8xlarge", job="opencost", label_beta_kubernetes_io_arch="amd64", label_beta_kubernetes_io_instance_type="m5a.8xlarge", label_beta_kubernetes_io_os="linux", label_failure_domain_beta_kubernetes_io_region="us-east-1", label_failure_domain_beta_kubernetes_io_zone="us-east-1b", label_k8s_io_cloud_provider_aws="d2cb972b7c823b27d1c0c05327c65dc2", label_karpenter_k8s_aws_instance_category="m", label_karpenter_k8s_aws_instance_cpu="32", label_karpenter_k8s_aws_instance_encryption_in_transit_supported="false", label_karpenter_k8s_aws_instance_family="m5a", label_karpenter_k8s_aws_instance_generation="5", label_karpenter_k8s_aws_instance_hypervisor="nitro", label_karpenter_k8s_aws_instance_memory="131072", label_karpenter_k8s_aws_instance_network_bandwidth="7500", label_karpenter_k8s_aws_instance_pods="234", label_karpenter_k8s_aws_instance_size="8xlarge", label_karpenter_sh_capacity_type="on-demand", label_karpenter_sh_initialized="true", label_karpenter_sh_provisioner_name="on-demand-amd64-gha", label_karpenter_sh_registered="true", label_kubernetes_io_arch="amd64", label_kubernetes_io_hostname="ip-10-1-120-2.ec2.internal", label_kubernetes_io_os="linux", label_node_kubernetes_io_instance_type="m5a.8xlarge", label_topology_ebs_csi_aws_com_zone="us-east-1b", label_topology_kubernetes_io_region="us-east-1", label_topology_kubernetes_io_zone="us-east-1b", namespace="opencost", node="ip-10-1-120-2.ec2.internal", pod="opencost-dfcd9d968-44vn4", service="opencost"}, {container="opencost", endpoint="http", instance="10.1.116.161:9003", instance_type="m5a.8xlarge", job="opencost", label_beta_kubernetes_io_arch="amd64", label_beta_kubernetes_io_instance_type="m5a.8xlarge", label_beta_kubernetes_io_os="linux", label_failure_domain_beta_kubernetes_io_region="us-east-1", label_failure_domain_beta_kubernetes_io_zone="us-east-1b", label_k8s_io_cloud_provider_aws="d2cb972b7c823b27d1c0c05327c65dc2", label_karpenter_k8s_aws_instance_category="m", label_karpenter_k8s_aws_instance_cpu="32", label_karpenter_k8s_aws_instance_encryption_in_transit_supported="false", label_karpenter_k8s_aws_instance_family="m5a", label_karpenter_k8s_aws_instance_generation="5", label_karpenter_k8s_aws_instance_hypervisor="nitro", label_karpenter_k8s_aws_instance_memory="131072", label_karpenter_k8s_aws_instance_network_bandwidth="7500", label_karpenter_k8s_aws_instance_pods="234", label_karpenter_k8s_aws_instance_size="8xlarge", label_karpenter_sh_capacity_type="on-demand", label_karpenter_sh_provisioner_name="on-demand-amd64-gha", label_karpenter_sh_registered="true", label_kubernetes_io_arch="amd64", label_kubernetes_io_hostname="ip-10-1-120-2.ec2.internal", label_kubernetes_io_os="linux", label_node_kubernetes_io_instance_type="m5a.8xlarge", label_topology_kubernetes_io_region="us-east-1", label_topology_kubernetes_io_zone="us-east-1b", namespace="opencost", node="ip-10-1-120-2.ec2.internal", pod="opencost-dfcd9d968-44vn4", service="opencost"}];many-to-many matching not allowed: matching labels must be unique on one side
