### PR TITLE
Store and reference cloud API key in secret

### DIFF
--- a/charts/opencost/templates/deployment.yaml
+++ b/charts/opencost/templates/deployment.yaml
@@ -83,7 +83,10 @@ spec:
               value: {{ include "opencost.prometheusServerEndpoint" . | quote }}
             {{- if .Values.opencost.exporter.cloudProviderApiKey }}
             - name: CLOUD_PROVIDER_API_KEY
-              value: {{ .Values.opencost.exporter.cloudProviderApiKey | quote }}
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "opencost.prometheus.secretname" . }}
+                  key: CLOUD_PROVIDER_API_KEY
             {{- end }}
             - name: CLUSTER_ID
               value: {{ .Values.opencost.exporter.defaultClusterId | quote }}

--- a/charts/opencost/templates/secret.yaml
+++ b/charts/opencost/templates/secret.yaml
@@ -1,4 +1,4 @@
-{{- if or .Values.opencost.prometheus.username .Values.opencost.prometheus.password .Values.opencost.prometheus.bearer_token .Values.opencost.exporter.aws.access_key_id }}
+{{- if or .Values.opencost.prometheus.username .Values.opencost.prometheus.password .Values.opencost.prometheus.bearer_token .Values.opencost.exporter.aws.access_key_id .Values.opencost.exporter.cloudProviderApiKey }}
 apiVersion: v1
 kind: Secret
 metadata:
@@ -22,5 +22,8 @@ data:
   {{- end }}
   {{- if .Values.opencost.exporter.aws.access_key_id }}
   AWS_SECRET_ACCESS_KEY: {{ .Values.opencost.exporter.aws.secret_access_key | b64enc | quote }}
+  {{- end }}
+  {{- if .Values.opencost.exporter.cloudProviderApiKey }}
+  CLOUD_PROVIDER_API_KEY: {{ .Values.opencost.exporter.cloudProviderApiKey | b64enc | quote }}
   {{- end }}
 {{- end }}


### PR DESCRIPTION
The `cloudProviderApiKey` value should be stored in a secret and referenced from this secret than exposing it. IT Sec people would thank for this.