### PR TITLE
Bump to OpenCost 1.106.2, a minor release.

### DIFF
--- a/charts/opencost/Chart.yaml
+++ b/charts/opencost/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v2
-appVersion: 1.106.1
+appVersion: 1.106.2
 name: opencost
 description: OpenCost and OpenCost UI
 type: application
@@ -9,7 +9,7 @@ keywords:
   - kubecost
   - opencost
   - monitoring
-version: 1.20.0
+version: 1.20.1
 maintainers:
   - name: mattray
     url: https://mattray.dev

--- a/charts/opencost/README.md
+++ b/charts/opencost/README.md
@@ -2,9 +2,9 @@
 
 OpenCost and OpenCost UI
 
-![Version: 1.20.0](https://img.shields.io/badge/Version-1.20.0-informational?style=flat-square)
+![Version: 1.20.1](https://img.shields.io/badge/Version-1.20.0-informational?style=flat-square)
 ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
-![AppVersion: 1.106.1](https://img.shields.io/badge/AppVersion-1.106.1-informational?style=flat-square)
+![AppVersion: 1.106.2](https://img.shields.io/badge/AppVersion-1.106.2-informational?style=flat-square)
 
 ## Maintainers
 


### PR DESCRIPTION
1.106.2 was released, it's just a bump for CVEs in the underlying containers.