### PR TITLE
Provider related custom pricing config file name

### DIFF
--- a/charts/opencost/Chart.yaml
+++ b/charts/opencost/Chart.yaml
@@ -9,7 +9,7 @@ keywords:
   - kubecost
   - opencost
   - monitoring
-version: 1.26.1
+version: 1.26.2
 maintainers:
   - name: mattray
     url: https://mattray.dev

--- a/charts/opencost/templates/_helpers.tpl
+++ b/charts/opencost/templates/_helpers.tpl
@@ -123,3 +123,14 @@ Check that the config is valid
     {{- end -}}
   {{- end -}}
 {{- end -}}
+
+{{/*
+Define opencost config file name
+*/}}
+{{- define "opencost.configFileName" -}}
+  {{- if  eq .Values.opencost.customPricing.provider "custom" -}}
+    {{- print "default" -}}
+  {{- else -}}
+    {{- .Values.opencost.customPricing.provider -}}
+  {{- end -}}
+{{- end -}}

--- a/charts/opencost/templates/configmap-custom-pricing.yaml
+++ b/charts/opencost/templates/configmap-custom-pricing.yaml
@@ -4,7 +4,7 @@ kind: ConfigMap
 metadata:
   name: {{ .Values.opencost.customPricing.configmapName }}
 data:
-  default.json: |-
+  {{ include "opencost.configFileName" . }}.json: |-
     {
 {{- range $key, $val := .Values.opencost.customPricing.costModel }}
 {{ $key | quote | indent 6}}: {{ $val | quote }},


### PR DESCRIPTION
Respect the configured provider to name the config file accordingly, so OpenCost can fetch spot data from s3.

RESOLVES: #129