### PR TITLE
1.107.0 release and revert to standard quay.io image repositories

### DIFF
--- a/charts/opencost/Chart.yaml
+++ b/charts/opencost/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v2
-appVersion: 1.106.4
+appVersion: 1.107.0
 name: opencost
 description: OpenCost and OpenCost UI
 type: application
@@ -9,7 +9,7 @@ keywords:
   - kubecost
   - opencost
   - monitoring
-version: 1.26.0
+version: 1.26.1
 maintainers:
   - name: mattray
     url: https://mattray.dev

--- a/charts/opencost/README.md
+++ b/charts/opencost/README.md
@@ -2,9 +2,9 @@
 
 OpenCost and OpenCost UI
 
-![Version: 1.23.0](https://img.shields.io/badge/Version-1.23.0-informational?style=flat-square)
+![Version: 1.26.1](https://img.shields.io/badge/Version-1.26.1-informational?style=flat-square)
 ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
-![AppVersion: 1.106.4](https://img.shields.io/badge/AppVersion-1.106.4-informational?style=flat-square)
+![AppVersion: 1.107.0](https://img.shields.io/badge/AppVersion-1.107.0-informational?style=flat-square)
 
 ## Maintainers
 

--- a/charts/opencost/values.yaml
+++ b/charts/opencost/values.yaml
@@ -68,9 +68,9 @@ opencost:
     defaultClusterId: 'default-cluster'
     image:
       # -- Exporter container image registry
-      registry: gcr.io
+      registry: quay.io
       # -- Exporter container image name
-      repository: kubecost1/opencost
+      repository: kubecost1/kubecost-cost-model
       # -- Exporter container image tag
       # @default -- `""` (use appVersion in Chart.yaml)
       tag: "latest"
@@ -267,7 +267,7 @@ opencost:
     enabled: true
     image:
       # -- UI container image registry
-      registry: gcr.io
+      registry: quay.io
       # -- UI container image name
       repository: kubecost1/opencost-ui
       # -- UI container image tag


### PR DESCRIPTION
During testing for the Cloud Costs feature the default repository was set to gcr.io, but that's not where builds are published by default. Restores back to the previous defaults and bumps for the new 1.107.0 release