### PR TITLE
add in fullImageName to support development envs

### DIFF
--- a/charts/opencost/templates/deployment.yaml
+++ b/charts/opencost/templates/deployment.yaml
@@ -47,7 +47,11 @@ spec:
       {{- end }}
       containers:
         - name: {{ include "opencost.fullname" . }}
+          {{- if .Values.opencost.exporter.image.fullImageName }}
+          image: {{ .Values.opencost.exporter.image.fullImageName }}
+          {{- else }}
           image: "{{ .Values.opencost.exporter.image.registry }}/{{ .Values.opencost.exporter.image.repository }}:{{ .Values.opencost.exporter.image.tag | default (printf "prod-%s" .Chart.AppVersion) }}"
+          {{- end}}
           imagePullPolicy: {{ .Values.opencost.exporter.image.pullPolicy }}
           args:
           {{- range .Values.opencost.exporter.extraArgs }}
@@ -189,7 +193,11 @@ spec:
           {{- end }}
         {{- if .Values.opencost.ui.enabled }}
         - name: opencost-ui
-          image:  "{{ .Values.opencost.ui.image.registry }}/{{ .Values.opencost.ui.image.repository }}:{{ .Values.opencost.ui.image.tag | default (printf "prod-%s" .Chart.AppVersion) }}"
+          {{- if .Values.opencost.ui.image.fullImageName }}
+          image: {{ .Values.opencost.ui.image.fullImageName }}
+          {{- else}}
+          image: "{{ .Values.opencost.ui.image.registry }}/{{ .Values.opencost.ui.image.repository }}:{{ .Values.opencost.ui.image.tag | default (printf "prod-%s" .Chart.AppVersion) }}"
+          {{- end }}
           imagePullPolicy: {{ .Values.opencost.ui.image.pullPolicy }}
           ports:
             - containerPort: 9090

--- a/charts/opencost/values.yaml
+++ b/charts/opencost/values.yaml
@@ -76,6 +76,8 @@ opencost:
       tag: "latest"
       # -- Exporter container image pull policy
       pullPolicy: IfNotPresent
+      # -- Override the full image name for development purposes
+      fullImageName: null
     # -- List of extra arguments for the command, e.g.: log-format=json
     extraArgs: []
     # -- Number of OpenCost replicas to run
@@ -275,6 +277,8 @@ opencost:
       tag: "latest"
       # -- UI container image pull policy
       pullPolicy: IfNotPresent
+      # -- Override the full image name for development purposes
+      fullImageName: null
     resources:
       # -- CPU/Memory resource requests
       requests:


### PR DESCRIPTION
In order to use [tilt](tilt.dev), OpenCost's helm chart needs to support a value that is the 'fullImageName' of a docker image, to increase flexibility for development environments - particularly the case of images going to a locally run cluster (like kind or minikube) and do not need to be pushed to docker.hub or another image repository.

This is also designed to align with an identical feature in the Kubecost helm charts.