### PR TITLE
feat: adding namespace override

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,11 +3,11 @@
 
 ## Maintainers
 
-| Name | Email | Url |
-| ---- | ------ | --- |
-| mattray | github@mattray.dev | <https://mattray.dev> |
-| toscott |  |
-| brito-rafa |  |
+| Name |
+| ---- |
+| mattray |
+| toscott |
+| brito-rafa |
 
 ## Usage
 

--- a/charts/opencost/Chart.yaml
+++ b/charts/opencost/Chart.yaml
@@ -9,9 +9,9 @@ keywords:
   - kubecost
   - opencost
   - monitoring
-version: 1.28.3
+version: 1.29.0
 maintainers:
   - name: mattray
-    url: https://mattray.dev
   - name: toscott
+  - name: brito-rafa
 home: https://github.com/opencost/opencost-helm-chart

--- a/charts/opencost/README.md
+++ b/charts/opencost/README.md
@@ -2,7 +2,7 @@
 
 OpenCost and OpenCost UI
 
-![Version: 1.28.2](https://img.shields.io/badge/Version-1.28.2-informational?style=flat-square)
+![Version: 1.29.0](https://img.shields.io/badge/Version-1.29.0-informational?style=flat-square)
 ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
 ![AppVersion: 1.108.0](https://img.shields.io/badge/AppVersion-1.108.0-informational?style=flat-square)
 

--- a/charts/opencost/README.md.gotmpl
+++ b/charts/opencost/README.md.gotmpl
@@ -10,11 +10,30 @@
 
 ## Installing the Chart
 
-To install the chart with the release name `opencost`:
+To install the chart with the release name `opencost` on `opencost` namespace:
 
 ```console
-$ helm install opencost opencost/{{ template "chart.name" . }}
+$ helm install opencost opencost/{{ template "chart.name" . }} --namespace opencost --create-namespace
 ```
+
+In order to have a working opencost installation, you need to provide one running instance of Prometheus.
+The following will install a prometheus instance on the namespace `prometheus-system`, where the default helm chart is expecting:
+
+```
+helm install prometheus --repo https://prometheus-community.github.io/helm-charts prometheus \
+  --namespace prometheus-system --create-namespace \
+  --set prometheus-pushgateway.enabled=false \
+  --set alertmanager.enabled=false \
+  -f https://raw.githubusercontent.com/opencost/opencost/develop/kubernetes/prometheus/extraScrapeConfigs.yaml
+```
+
+During installation, you can specify the following parameters if you have your own internal Prometheus:
+
+```
+`--set opencost.prometheus.internal.namespace=<your-namespace>`
+`--set opencost.prometheus.internal.service=<your-service>`
+```
+
 
 {{ template "chart.requirementsSection" . }}
 

--- a/charts/opencost/templates/_helpers.tpl
+++ b/charts/opencost/templates/_helpers.tpl
@@ -31,6 +31,17 @@ We truncate at 63 chars because some Kubernetes name fields are limited to this 
 {{- end -}}
 
 {{/*
+Allow the release namespace to be overridden
+*/}}
+{{- define "opencost.namespace" -}}
+  {{- if .Values.namespaceOverride -}}
+    {{- .Values.namespaceOverride -}}
+  {{- else -}}
+    {{- .Release.Namespace -}}
+  {{- end -}}
+{{- end -}}
+
+{{/*
 Create a default fully qualified app name.
 We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
 */}}

--- a/charts/opencost/templates/clusterrolebinding.yaml
+++ b/charts/opencost/templates/clusterrolebinding.yaml
@@ -14,5 +14,5 @@ roleRef:
 subjects:
   - kind: ServiceAccount
     name: {{ template "opencost.serviceAccountName" . }}
-    namespace: {{ .Release.Namespace }}
+    namespace: {{ include "opencost.namespace" . }}
 {{- end }}

--- a/charts/opencost/templates/configmap-custom-pricing.yaml
+++ b/charts/opencost/templates/configmap-custom-pricing.yaml
@@ -3,6 +3,7 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: {{ .Values.opencost.customPricing.configmapName }}
+  namespace: {{ include "opencost.namespace" . }}
 data:
   {{ include "opencost.configFileName" . }}.json: |-
     {

--- a/charts/opencost/templates/deployment.yaml
+++ b/charts/opencost/templates/deployment.yaml
@@ -3,6 +3,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ include "opencost.fullname" . }}
+  namespace: {{ include "opencost.namespace" . }}
   labels: {{- include "opencost.labels" . | nindent 4 }}
   {{- with .Values.annotations }}
   annotations: {{- toYaml . | nindent 4 }}

--- a/charts/opencost/templates/ingress.yaml
+++ b/charts/opencost/templates/ingress.yaml
@@ -3,6 +3,7 @@ apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   name: {{ include "opencost.fullname" . }}-ingress
+  namespace: {{ include "opencost.namespace" . }}
   labels: {{- include "opencost.labels" . | nindent 4 }}
   {{- with .Values.opencost.ui.ingress.annotations }}
   annotations: {{- toYaml . | nindent 4 }}

--- a/charts/opencost/templates/networkpolicy.yaml
+++ b/charts/opencost/templates/networkpolicy.yaml
@@ -6,7 +6,7 @@
 kind: NetworkPolicy
 metadata:
   name: {{ .Release.Name }}-opencost
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ include "opencost.namespace" . }}
 spec:
   podSelector:
     matchLabels:

--- a/charts/opencost/templates/pvc.yaml
+++ b/charts/opencost/templates/pvc.yaml
@@ -3,6 +3,7 @@ kind: PersistentVolumeClaim
 apiVersion: v1
 metadata:
   name: {{ include "opencost.fullname" . }}-pvc
+  namespace: {{ include "opencost.namespace" . }}
   labels: {{- include "opencost.labels" . | nindent 4 }}
   {{- with .Values.opencost.exporter.persistence.annotations  }}
   annotations: {{- toYaml . | nindent 4 }}

--- a/charts/opencost/templates/secret.yaml
+++ b/charts/opencost/templates/secret.yaml
@@ -3,6 +3,7 @@ apiVersion: v1
 kind: Secret
 metadata:
   name: {{ include "opencost.prometheus.secretname" . }}
+  namespace: {{ include "opencost.namespace" . }}
   labels: {{- include "opencost.labels" . | nindent 4 }}
   {{- with .Values.secretAnnotations }}
   annotations: {{- toYaml . | nindent 4 }}

--- a/charts/opencost/templates/service.yaml
+++ b/charts/opencost/templates/service.yaml
@@ -3,6 +3,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: {{ include "opencost.fullname" . }}
+  namespace: {{ include "opencost.namespace" . }}
   labels:
     {{- include "opencost.labels" . | nindent 4 }}
     {{- with .Values.service.labels }}

--- a/charts/opencost/templates/serviceaccount.yaml
+++ b/charts/opencost/templates/serviceaccount.yaml
@@ -3,6 +3,7 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: {{ template "opencost.serviceAccountName" . }}
+  namespace: {{ include "opencost.namespace" . }}
   labels: {{- include "opencost.labels" . | nindent 4 }}
   {{- with .Values.serviceAccount.annotations }}
   annotations: {{- toYaml . | nindent 4 }}

--- a/charts/opencost/values.yaml
+++ b/charts/opencost/values.yaml
@@ -2,6 +2,8 @@
 nameOverride: ""
 # -- Overwrite all resources name created by the chart
 fullnameOverride: ""
+# -- Override the deployment namespace
+namespaceOverride: ""
 
 # -- List of secret names to use for pulling the images
 imagePullSecrets: []


### PR DESCRIPTION
Adding parameter `namespaceOverride` as requests on #161.

When using `--set namespaceOverride=<namespace>`, it is required to pre-create the namespace.

Improved the README as well.

Log of the test:

```
# create the namespace
% k create ns override

% helm install opencost-override ./charts/opencost --set namespaceOverride=override
NAME: opencost-override
LAST DEPLOYED: Thu Jan 11 14:49:52 2024
NAMESPACE: default  <-----------
STATUS: deployed
REVISION: 1
TEST SUITE: None

% helm install opencost-vanilla ./charts/opencost --namespace=vanilla --create-namespace 
NAME: opencost-vanilla
LAST DEPLOYED: Thu Jan 11 14:50:14 2024
NAMESPACE: vanilla
STATUS: deployed
REVISION: 1
TEST SUITE: None

% k get pod -n override -w
NAME                                 READY   STATUS    RESTARTS   AGE
opencost-override-844bd7498f-w5szq   1/2     Running   0          66s
opencost-override-844bd7498f-w5szq   2/2     Running   0          2m6s   <------ running

% k get pod -n vanilla    
NAME                                READY   STATUS    RESTARTS   AGE
opencost-vanilla-78cb5bfbc9-5jg4j   2/2     Running   0          2m3s
```