### PR TITLE
feat: `startupProbe` to avoid a long initial delay seconds for liveness probe

### DIFF
--- a/charts/opencost/Chart.yaml
+++ b/charts/opencost/Chart.yaml
@@ -9,7 +9,7 @@ keywords:
   - kubecost
   - opencost
   - monitoring
-version: 1.29.0
+version: 1.29.1
 maintainers:
   - name: mattray
   - name: toscott

--- a/charts/opencost/templates/deployment.yaml
+++ b/charts/opencost/templates/deployment.yaml
@@ -62,6 +62,15 @@ spec:
             - containerPort: {{ .Values.opencost.exporter.apiPort }}
               name: http
           resources: {{- toYaml .Values.opencost.exporter.resources | nindent 12 }}
+          {{- if .Values.opencost.exporter.startupProbe.enabled }}
+          startupProbe:
+            httpGet:
+              path: {{ .Values.opencost.exporter.startupProbe.path }}
+              port: {{ .Values.opencost.exporter.apiPort }}
+            initialDelaySeconds: {{ .Values.opencost.exporter.startupProbe.initialDelaySeconds }}
+            periodSeconds: {{ .Values.opencost.exporter.startupProbe.periodSeconds }}
+            failureThreshold: {{ .Values.opencost.exporter.startupProbe.failureThreshold }}
+          {{- end }}
           {{- if .Values.opencost.exporter.livenessProbe.enabled }}
           livenessProbe:
             httpGet:

--- a/charts/opencost/values.yaml
+++ b/charts/opencost/values.yaml
@@ -114,6 +114,18 @@ opencost:
       limits:
         cpu: '999m'
         memory: '1Gi'
+    # Startup probe configuration
+    startupProbe:
+      # -- Whether probe is enabled
+      enabled: true
+      # -- Probe path
+      path: /healthz
+      # -- Number of seconds before probe is initiated
+      initialDelaySeconds: 10
+      # -- Probe frequency in seconds
+      periodSeconds: 5
+      # -- Number of failures for probe to be considered failed
+      failureThreshold: 30
     # Liveness probe configuration
     livenessProbe:
       # -- Whether probe is enabled
@@ -121,9 +133,9 @@ opencost:
       # -- Probe path
       path: /healthz
       # -- Number of seconds before probe is initiated
-      initialDelaySeconds: 120
+      initialDelaySeconds: 10
       # -- Probe frequency in seconds
-      periodSeconds: 10
+      periodSeconds: 20
       # -- Number of failures for probe to be considered failed
       failureThreshold: 3
     # Readiness probe configuration
@@ -133,7 +145,7 @@ opencost:
       # -- Probe path
       path: /healthz
       # -- Number of seconds before probe is initiated
-      initialDelaySeconds: 120
+      initialDelaySeconds: 10
       # -- Probe frequency in seconds
       periodSeconds: 10
       # -- Number of failures for probe to be considered failed


### PR DESCRIPTION
https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes/

Kubernetes Docs: 

>The kubelet uses startup probes to know when a container application has started. If such a probe is configured, liveness and readiness probes do not start until it succeeds, making sure those probes don't interfere with the application startup. This can be used to adopt liveness checks on slow starting containers, avoiding them getting killed by the kubelet before they are up and running.

