### PR TITLE
feat: add ability to set KSM settings via helm chart values

### DIFF
--- a/charts/opencost/Chart.yaml
+++ b/charts/opencost/Chart.yaml
@@ -9,7 +9,7 @@ keywords:
   - finops
   - monitoring
   - opencost
-version: 1.31.0
+version: 1.32.0
 maintainers:
   - name: mattray
   - name: toscott

--- a/charts/opencost/templates/deployment.yaml
+++ b/charts/opencost/templates/deployment.yaml
@@ -198,6 +198,22 @@ spec:
               value: {{ .Values.opencost.cloudCost.queryWindowDays | quote }}
             - name: CLOUD_COST_RUN_WINDOW_DAYS
               value: {{ .Values.opencost.cloudCost.runWindowDays | quote }}
+            {{- if .Values.opencost.metrics.kubeStateMetrics.emitPodAnnotations }}
+            - name: EMIT_POD_ANNOTATIONS_METRIC
+              value: {{ ( .Values.opencost.metrics.kubeStateMetrics.emitPodAnnotations) | quote }}
+            {{- end }}
+            {{- if .Values.opencost.metrics.kubeStateMetrics.emitNamespaceAnnotations }}
+            - name: EMIT_NAMESPACE_ANNOTATIONS_METRIC
+              value: {{ ( .Values.opencost.metrics.kubeStateMetrics.emitNamespaceAnnotations) | quote}}
+            {{- end }}
+            {{- if .Values.opencost.metrics.kubeStateMetrics.emitKsmV1Metrics }}
+            - name: EMIT_KSM_V1_METRICS
+              value: {{ ( .Values.opencost.metrics.kubeStateMetrics.emitKsmV1Metrics) | quote }}
+            {{- end }}
+            {{- if .Values.opencost.metrics.kubeStateMetrics.emitKsmV1MetricsOnly }}
+            - name: EMIT_KSM_V1_METRICS_ONLY 
+              value: {{ ( .Values.opencost.metrics.kubeStateMetrics.emitKsmV1MetricsOnly) | quote }}
+            {{- end }}
             # Add any additional provided variables
             {{- range $key, $value := .Values.opencost.exporter.extraEnv }}
             - name: {{ $key }}

--- a/charts/opencost/values.yaml
+++ b/charts/opencost/values.yaml
@@ -255,6 +255,16 @@ opencost:
 
 
   metrics:
+    kubeStateMetrics:
+      # -- Enable emission of pod annotations
+      emitPodAnnotations: ""
+      # -- Enable emission of namespace annotations
+      emitNamespaceAnnotations: ""
+      # -- Enable emission of KSM v1 metrics
+      emitKsmV1Metrics: ""
+      # -- Enable only emission of KSM v1 metrics that do not exist in KSM 2 by default
+      emitKsmV1MetricsOnly: ""
+
     serviceMonitor:
       # -- Create ServiceMonitor resource for scraping metrics using PrometheusOperator
       enabled: false


### PR DESCRIPTION
I looked deeper into the helm chart and I noticed two things:

1. IMHO the section name `opencostMetrics` does not fit well. Therefore I would suggest to set it to `opencost.metrics.kubeStateMetrics`
2. It is not common in this helm chart to use the `default` function, which is used in the [cost-analyzer-helm-chart](https://github.com/kubecost/cost-analyzer-helm-chart/blob/develop/cost-analyzer/). 

My suggestion in this draft is to set only the settings configured by the user. In other words, not to set default values at all. Example configuration:
```YAML
kubeStateMetrics:
  emitPodAnnotations: ""
  emitNamespaceAnnotations: ""
  emitKsmV1Metrics: "" 
  emitKsmV1MetricsOnly: ""
```

If default values are preferred, I currently see two options:
1. Use the same approach as the cost-analyzer. Example configuration: 
```YAML
kubeStateMetrics: {}
  # emitPodAnnotations: false
  # emitNamespaceAnnotations: false
  # emitKsmV1Metrics: true
  # emitKsmV1MetricsOnly: false
```

2. Set the default values directly in the values file. However, this would result in always setting these values as an environment variable. Example configuration: 
```YAML
kubeStateMetrics:
  emitPodAnnotations: false
  emitNamespaceAnnotations: false
  emitKsmV1Metrics: true
  emitKsmV1MetricsOnly: false
```

I would like to hear your comments! 