### PR TITLE
Support for extra egress rules and metricConfig ConfigMap

### DIFF
--- a/charts/opencost/Chart.yaml
+++ b/charts/opencost/Chart.yaml
@@ -9,7 +9,7 @@ keywords:
   - finops
   - monitoring
   - opencost
-version: 1.32.0
+version: 1.33.0
 maintainers:
   - name: mattray
   - name: toscott

--- a/charts/opencost/templates/configmap-metrics-config.yaml
+++ b/charts/opencost/templates/configmap-metrics-config.yaml
@@ -1,0 +1,11 @@
+{{- if .Values.opencost.metrics.config.enabled }}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ .Release.Name }}-metrics-config
+  namespace: {{ include "opencost.namespace" . }}
+  labels: {{- include "opencost.labels" . | nindent 4 }}
+data:
+  metrics.json: |-
+    {"disabledMetrics": {{ toJson .Values.opencost.metrics.config.disabledMetrics }} }
+{{- end }}

--- a/charts/opencost/templates/deployment.yaml
+++ b/charts/opencost/templates/deployment.yaml
@@ -111,6 +111,12 @@ spec:
               value: {{ .Values.loglevel }}
             - name: CUSTOM_COST_ENABLED
               value: {{ .Values.plugins.enabled | quote }}
+            - name: KUBECOST_NAMESPACE
+              value: {{ include "opencost.namespace" . }}
+            {{- if .Values.opencost.metrics.config.enabled }}
+            - name: METRICS_CONFIGMAP_NAME
+              value: {{ .Release.Name }}-metrics-config
+            {{- end }}
             {{- if .Values.opencost.exporter.apiPort }}
             - name: API_PORT
               value: {{ .Values.opencost.exporter.apiPort | quote }}

--- a/charts/opencost/templates/networkpolicy.yaml
+++ b/charts/opencost/templates/networkpolicy.yaml
@@ -42,5 +42,8 @@ spec:
         {{- end }}
       ports:
       - port: {{ .Values.networkPolicies.prometheus.port }}
+    {{- if .Values.networkPolicies.extraEgress -}}
+      {{ toYaml .Values.networkPolicies.extraEgress | nindent 4 }}
+    {{- end -}}
 {{- end }}
 {{- end }}

--- a/charts/opencost/values.yaml
+++ b/charts/opencost/values.yaml
@@ -297,7 +297,7 @@ opencost:
         # certFile: /etc/prom-certs/cert-chain.pem
         # insecureSkipVerify: true
         # keyFile: /etc/prom-certs/key.pem
-    
+
     config:
       # -- Enables creating the metrics.json configuration as a ConfigMap
       enabled: false

--- a/charts/opencost/values.yaml
+++ b/charts/opencost/values.yaml
@@ -297,6 +297,14 @@ opencost:
         # certFile: /etc/prom-certs/cert-chain.pem
         # insecureSkipVerify: true
         # keyFile: /etc/prom-certs/key.pem
+    
+    config:
+      # -- Enables creating the metrics.json configuration as a ConfigMap
+      enabled: false
+      # -- List of metrics to be disabled
+      disabledMetrics: []
+      # - <metric-to-be-disabled>
+      # - <metric-to-be-disabled>
 
   prometheus:
     # -- Secret name that contains credentials for Prometheus

--- a/charts/opencost/values.yaml
+++ b/charts/opencost/values.yaml
@@ -63,6 +63,9 @@ networkPolicies:
     labels:
       app.kubernetes.io/name: prometheus
 
+  # -- Extra egress rule
+  extraEgress: []
+
 # --  Strategy to be used for the Deployment
 updateStrategy:
   rollingUpdate:


### PR DESCRIPTION
* Support extra egress rules. This is useful for environments that have default deny and we need to specify that OpenCost can download pricing data from `aws`.
* Adds support to be able to specify `disabledMetrics` via `metrics-config`. This is useful when you only want to emit KSM v2 metrics and need to suppress duplicate metrics.