### PR TITLE
feat: add ArtifactHub badges to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 # OpenCost Helm Chart
-[![License](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](https://opensource.org/licenses/Apache-2.0) ![Chart Publish](https://github.com/opencost/opencost-helm-chart/workflows/chart-publish/badge.svg?branch=main) [![Releases downloads](https://img.shields.io/github/downloads/opencost/opencost-helm-chart/total.svg)](https://github.com/opencost/opencost-helm-charts/releases)
-
+[![License](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](https://opensource.org/licenses/Apache-2.0)
+![Chart Publish](https://github.com/opencost/opencost-helm-chart/workflows/chart-publish/badge.svg?branch=main)
+[![Releases downloads](https://img.shields.io/github/downloads/opencost/opencost-helm-chart/total.svg)](https://github.com/opencost/opencost-helm-charts/releases)
+[![Artifact HUB](https://img.shields.io/endpoint?url=https://artifacthub.io/badge/repository/opencost)](https://artifacthub.io/packages/search?org=opencost)
 ## Maintainers
 
 | Name |

--- a/charts/opencost/Chart.yaml
+++ b/charts/opencost/Chart.yaml
@@ -9,7 +9,7 @@ keywords:
   - finops
   - monitoring
   - opencost
-version: 1.33.1
+version: 1.33.2
 maintainers:
   - name: mattray
     url: https://mattray.dev

--- a/charts/opencost/README.md
+++ b/charts/opencost/README.md
@@ -5,6 +5,8 @@ OpenCost and OpenCost UI
 ![Version: 1.33.1](https://img.shields.io/badge/Version-1.33.1-informational?style=flat-square)
 ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
 ![AppVersion: 1.109.0](https://img.shields.io/badge/AppVersion-1.109.0-informational?style=flat-square)
+[![Artifact Hub](https://img.shields.io/endpoint?url=https://artifacthub.io/badge/repository/opencost)](https://artifacthub.io/packages/search?repo=opencost)
+[![Artifact Hub](https://img.shields.io/endpoint?url=https://artifacthub.io/badge/repository/opencost-oci)](https://artifacthub.io/packages/search?repo=opencost-oci)
 
 ## Maintainers
 

--- a/charts/opencost/README.md.gotmpl
+++ b/charts/opencost/README.md.gotmpl
@@ -5,6 +5,9 @@
 {{ template "chart.versionBadge" . }}
 {{ template "chart.typeBadge" . }}
 {{ template "chart.appVersionBadge" . }}
+[![Artifact Hub](https://img.shields.io/endpoint?url=https://artifacthub.io/badge/repository/opencost)](https://artifacthub.io/packages/search?repo=opencost)
+[![Artifact Hub](https://img.shields.io/endpoint?url=https://artifacthub.io/badge/repository/opencost-oci)](https://artifacthub.io/packages/search?repo=opencost-oci)
+
 
 {{ template "chart.maintainersSection" . }}
 


### PR DESCRIPTION
- Badges of README.md are now listed line by line for a better overview
- Added org badge to the README.md
- Added repo badges to the charts/opencost/README.md