### PR TITLE
chore(kubeStateMetrics): make it clear that the keys of kubeStateMetrics only accept booleans for the values

### DIFF
--- a/charts/opencost/Chart.yaml
+++ b/charts/opencost/Chart.yaml
@@ -9,7 +9,7 @@ keywords:
   - finops
   - monitoring
   - opencost
-version: 1.33.2
+version: 1.33.3
 maintainers:
   - name: mattray
     url: https://mattray.dev

--- a/charts/opencost/README.md
+++ b/charts/opencost/README.md
@@ -2,7 +2,7 @@
 
 OpenCost and OpenCost UI
 
-![Version: 1.33.1](https://img.shields.io/badge/Version-1.33.1-informational?style=flat-square)
+![Version: 1.33.3](https://img.shields.io/badge/Version-1.33.3-informational?style=flat-square)
 ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
 ![AppVersion: 1.109.0](https://img.shields.io/badge/AppVersion-1.109.0-informational?style=flat-square)
 [![Artifact Hub](https://img.shields.io/endpoint?url=https://artifacthub.io/badge/repository/opencost)](https://artifacthub.io/packages/search?repo=opencost)
@@ -97,10 +97,10 @@ $ helm install opencost opencost/opencost
 | opencost.extraContainers | list | `[]` | extra sidecars to add to the pod.  Useful for things like oauth-proxy for the UI |
 | opencost.metrics.config.disabledMetrics | list | `[]` | List of metrics to be disabled |
 | opencost.metrics.config.enabled | bool | `false` | Enables creating the metrics.json configuration as a ConfigMap |
-| opencost.metrics.kubeStateMetrics.emitKsmV1Metrics | string | `""` | Enable emission of KSM v1 metrics |
-| opencost.metrics.kubeStateMetrics.emitKsmV1MetricsOnly | string | `""` | Enable only emission of KSM v1 metrics that do not exist in KSM 2 by default |
-| opencost.metrics.kubeStateMetrics.emitNamespaceAnnotations | string | `""` | Enable emission of namespace annotations |
-| opencost.metrics.kubeStateMetrics.emitPodAnnotations | string | `""` | Enable emission of pod annotations |
+| opencost.metrics.kubeStateMetrics.emitKsmV1Metrics | bool | `nil` | Enable emission of KSM v1 metrics |
+| opencost.metrics.kubeStateMetrics.emitKsmV1MetricsOnly | bool | `nil` | Enable only emission of KSM v1 metrics that do not exist in KSM 2 by default |
+| opencost.metrics.kubeStateMetrics.emitNamespaceAnnotations | bool | `nil` | Enable emission of namespace annotations |
+| opencost.metrics.kubeStateMetrics.emitPodAnnotations | bool | `nil` | Enable emission of pod annotations |
 | opencost.metrics.serviceMonitor.additionalLabels | object | `{}` | Additional labels to add to the ServiceMonitor |
 | opencost.metrics.serviceMonitor.enabled | bool | `false` | Create ServiceMonitor resource for scraping metrics using PrometheusOperator |
 | opencost.metrics.serviceMonitor.extraEndpoints | list | `[]` | extra Endpoints to add to the ServiceMonitor.  Useful for scraping sidecars |

--- a/charts/opencost/templates/deployment.yaml
+++ b/charts/opencost/templates/deployment.yaml
@@ -204,21 +204,21 @@ spec:
               value: {{ .Values.opencost.cloudCost.queryWindowDays | quote }}
             - name: CLOUD_COST_RUN_WINDOW_DAYS
               value: {{ .Values.opencost.cloudCost.runWindowDays | quote }}
-            {{- if .Values.opencost.metrics.kubeStateMetrics.emitPodAnnotations }}
+            {{- if not (quote .Values.opencost.metrics.kubeStateMetrics.emitPodAnnotations | empty ) }}
             - name: EMIT_POD_ANNOTATIONS_METRIC
-              value: {{ ( .Values.opencost.metrics.kubeStateMetrics.emitPodAnnotations) | quote }}
+              value: {{ .Values.opencost.metrics.kubeStateMetrics.emitPodAnnotations | quote }}
             {{- end }}
-            {{- if .Values.opencost.metrics.kubeStateMetrics.emitNamespaceAnnotations }}
+            {{- if not (quote .Values.opencost.metrics.kubeStateMetrics.emitNamespaceAnnotations | empty ) }}
             - name: EMIT_NAMESPACE_ANNOTATIONS_METRIC
-              value: {{ ( .Values.opencost.metrics.kubeStateMetrics.emitNamespaceAnnotations) | quote}}
+              value: {{ .Values.opencost.metrics.kubeStateMetrics.emitNamespaceAnnotations | quote }}
             {{- end }}
-            {{- if .Values.opencost.metrics.kubeStateMetrics.emitKsmV1Metrics }}
+            {{- if not (quote .Values.opencost.metrics.kubeStateMetrics.emitKsmV1Metrics | empty ) }}
             - name: EMIT_KSM_V1_METRICS
-              value: {{ ( .Values.opencost.metrics.kubeStateMetrics.emitKsmV1Metrics) | quote }}
+              value: {{ .Values.opencost.metrics.kubeStateMetrics.emitKsmV1Metrics | quote }}
             {{- end }}
-            {{- if .Values.opencost.metrics.kubeStateMetrics.emitKsmV1MetricsOnly }}
+            {{- if not (quote .Values.opencost.metrics.kubeStateMetrics.emitKsmV1MetricsOnly | empty ) }}
             - name: EMIT_KSM_V1_METRICS_ONLY 
-              value: {{ ( .Values.opencost.metrics.kubeStateMetrics.emitKsmV1MetricsOnly) | quote }}
+              value: {{ .Values.opencost.metrics.kubeStateMetrics.emitKsmV1MetricsOnly | quote }}
             {{- end }}
             # Add any additional provided variables
             {{- range $key, $value := .Values.opencost.exporter.extraEnv }}

--- a/charts/opencost/values.yaml
+++ b/charts/opencost/values.yaml
@@ -259,14 +259,14 @@ opencost:
 
   metrics:
     kubeStateMetrics:
-      # -- Enable emission of pod annotations
-      emitPodAnnotations: ""
-      # -- Enable emission of namespace annotations
-      emitNamespaceAnnotations: ""
-      # -- Enable emission of KSM v1 metrics
-      emitKsmV1Metrics: ""
-      # -- Enable only emission of KSM v1 metrics that do not exist in KSM 2 by default
-      emitKsmV1MetricsOnly: ""
+      # -- (bool) Enable emission of pod annotations
+      emitPodAnnotations: ~
+      # -- (bool) Enable emission of namespace annotations
+      emitNamespaceAnnotations: ~
+      # -- (bool) Enable emission of KSM v1 metrics
+      emitKsmV1Metrics: ~
+      # -- (bool) Enable only emission of KSM v1 metrics that do not exist in KSM 2 by default
+      emitKsmV1MetricsOnly: ~
 
     serviceMonitor:
       # -- Create ServiceMonitor resource for scraping metrics using PrometheusOperator


### PR DESCRIPTION
Discussed with @mattray. This should provide a better usability. 