### PR TITLE
Option to use existing kubernetes secret 

### DIFF
--- a/charts/opencost/Chart.yaml
+++ b/charts/opencost/Chart.yaml
@@ -9,7 +9,7 @@ keywords:
   - finops
   - monitoring
   - opencost
-version: 1.33.3
+version: 1.34.0
 maintainers:
   - name: mattray
     url: https://mattray.dev

--- a/charts/opencost/README.md
+++ b/charts/opencost/README.md
@@ -117,7 +117,7 @@ $ helm install opencost opencost/opencost
 | opencost.prometheus.amp.workspaceId | string | `""` | Workspace ID for AMP |
 | opencost.prometheus.bearer_token | string | `""` | Prometheus Bearer token |
 | opencost.prometheus.bearer_token_key | string | `"DB_BEARER_TOKEN"` |  |
-| opencost.prometheus.existing_secret_name | string | `nil` | Existing secret name that contains credentials for Prometheus |
+| opencost.prometheus.existingSecretName | string | `nil` | Existing secret name that contains credentials for Prometheus |
 | opencost.prometheus.external.enabled | bool | `false` | Use external Prometheus (eg. Grafana Cloud) |
 | opencost.prometheus.external.url | string | `"https://prometheus.example.com/prometheus"` | External Prometheus url |
 | opencost.prometheus.internal.enabled | bool | `true` | Use in-cluster Prometheus |

--- a/charts/opencost/README.md
+++ b/charts/opencost/README.md
@@ -2,7 +2,7 @@
 
 OpenCost and OpenCost UI
 
-![Version: 1.33.3](https://img.shields.io/badge/Version-1.33.3-informational?style=flat-square)
+![Version: 1.34.0](https://img.shields.io/badge/Version-1.34.0-informational?style=flat-square)
 ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
 ![AppVersion: 1.109.0](https://img.shields.io/badge/AppVersion-1.109.0-informational?style=flat-square)
 [![Artifact Hub](https://img.shields.io/endpoint?url=https://artifacthub.io/badge/repository/opencost)](https://artifacthub.io/packages/search?repo=opencost)
@@ -117,6 +117,7 @@ $ helm install opencost opencost/opencost
 | opencost.prometheus.amp.workspaceId | string | `""` | Workspace ID for AMP |
 | opencost.prometheus.bearer_token | string | `""` | Prometheus Bearer token |
 | opencost.prometheus.bearer_token_key | string | `"DB_BEARER_TOKEN"` |  |
+| opencost.prometheus.existing_secret_name | string | `nil` | Existing secret name that contains credentials for Prometheus |
 | opencost.prometheus.external.enabled | bool | `false` | Use external Prometheus (eg. Grafana Cloud) |
 | opencost.prometheus.external.url | string | `"https://prometheus.example.com/prometheus"` | External Prometheus url |
 | opencost.prometheus.internal.enabled | bool | `true` | Use in-cluster Prometheus |

--- a/charts/opencost/templates/deployment.yaml
+++ b/charts/opencost/templates/deployment.yaml
@@ -146,25 +146,24 @@ spec:
                   name: {{ include "opencost.prometheus.secretname" . }}
                   key: AWS_SECRET_ACCESS_KEY
             {{- end }}
-            # If username, password or bearer_token are defined, pull from secrets
-            {{- if or .Values.opencost.prometheus.username (and .Values.opencost.prometheus.secret_name .Values.opencost.prometheus.username_key) }}
+            {{- if and .Values.opencost.prometheus.username_key (or .Values.opencost.prometheus.username .Values.opencost.prometheus.existingSecretName) }}
             - name: DB_BASIC_AUTH_USERNAME
               valueFrom:
                 secretKeyRef:
-                  name: {{ include "opencost.prometheus.secretname" . }}
+                  name: {{ .Values.opencost.prometheus.existingSecretName | default (include "opencost.prometheus.secretname" .) }}
                   key: {{ .Values.opencost.prometheus.username_key }}
             {{- end }}
-            {{- if or .Values.opencost.prometheus.password (and .Values.opencost.prometheus.secret_name .Values.opencost.prometheus.password_key) }}
+            {{- if and .Values.opencost.prometheus.password_key (or .Values.opencost.prometheus.password .Values.opencost.prometheus.existingSecretName) }}
             - name: DB_BASIC_AUTH_PW
               valueFrom:
                 secretKeyRef:
-                  name: {{ include "opencost.prometheus.secretname" . }}
+                  name: {{ .Values.opencost.prometheus.existingSecretName | default (include "opencost.prometheus.secretname" .) }}
                   key: {{ .Values.opencost.prometheus.password_key }}
-            {{- else if or .Values.opencost.prometheus.bearer_token (and .Values.opencost.prometheus.secret_name .Values.opencost.prometheus.bearer_token_key) }}
+            {{- else if and .Values.opencost.prometheus.bearer_token_key (or .Values.opencost.prometheus.bearer_token .Values.opencost.prometheus.existingSecretName) }}
             - name: DB_BEARER_TOKEN
               valueFrom:
                 secretKeyRef:
-                  name: {{ include "opencost.prometheus.secretname" . }}
+                  name: {{ .Values.opencost.prometheus.existingSecretName | default (include "opencost.prometheus.secretname" .) }}
                   key: {{ .Values.opencost.prometheus.bearer_token_key }}
             {{- end }}
             {{- if and .Values.opencost.exporter.persistence.enabled .Values.opencost.exporter.csv_path }}
@@ -217,7 +216,7 @@ spec:
               value: {{ .Values.opencost.metrics.kubeStateMetrics.emitKsmV1Metrics | quote }}
             {{- end }}
             {{- if not (quote .Values.opencost.metrics.kubeStateMetrics.emitKsmV1MetricsOnly | empty ) }}
-            - name: EMIT_KSM_V1_METRICS_ONLY 
+            - name: EMIT_KSM_V1_METRICS_ONLY
               value: {{ .Values.opencost.metrics.kubeStateMetrics.emitKsmV1MetricsOnly | quote }}
             {{- end }}
             # Add any additional provided variables
@@ -227,7 +226,7 @@ spec:
             {{- end }}
           {{- if or .Values.plugins.enabled .Values.opencost.exporter.persistence.enabled .Values.opencost.exporter.extraVolumeMounts .Values.opencost.customPricing.enabled .Values.opencost.cloudIntegrationSecret}}
           volumeMounts:
-            {{- if .Values.plugins.enabled }} 
+            {{- if .Values.plugins.enabled }}
             - mountPath: /opt/opencost/plugin
               name: plugins-dir
               readOnly: false

--- a/charts/opencost/values.yaml
+++ b/charts/opencost/values.yaml
@@ -309,6 +309,8 @@ opencost:
   prometheus:
     # -- Secret name that contains credentials for Prometheus
     secret_name: ~
+    # -- Existing secret name that contains credentials for Prometheus
+    existingSecretName: ~
     # -- Prometheus Basic auth username
     username: ""
     # -- Key in the secret that references the username


### PR DESCRIPTION
Hello, with current approach prometheus username and password should be added to values.yml, and helm create secret based on those values. But in case when secret already exist in kubernetes there is no way to use it with opencost helm cahrt. This PR allowing to use existing secrets