### PR TITLE
Fix support for disabledMetrics configmap

### DIFF
--- a/charts/opencost/Chart.yaml
+++ b/charts/opencost/Chart.yaml
@@ -9,7 +9,7 @@ keywords:
   - finops
   - monitoring
   - opencost
-version: 1.35.0
+version: 1.36.0
 maintainers:
   - name: mattray
     url: https://mattray.dev

--- a/charts/opencost/templates/configmap-metrics-config.yaml
+++ b/charts/opencost/templates/configmap-metrics-config.yaml
@@ -2,7 +2,7 @@
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: {{ .Release.Name }}-metrics-config
+  name: {{ .Values.opencost.metrics.config.configmapName }}
   namespace: {{ include "opencost.namespace" . }}
   labels: {{- include "opencost.labels" . | nindent 4 }}
 data:

--- a/charts/opencost/templates/deployment.yaml
+++ b/charts/opencost/templates/deployment.yaml
@@ -115,7 +115,7 @@ spec:
               value: {{ include "opencost.namespace" . }}
             {{- if .Values.opencost.metrics.config.enabled }}
             - name: METRICS_CONFIGMAP_NAME
-              value: {{ .Release.Name }}-metrics-config
+              value: {{ .Values.opencost.metrics.config.configmapName }}
             {{- end }}
             {{- if .Values.opencost.exporter.apiPort }}
             - name: API_PORT
@@ -245,6 +245,13 @@ spec:
             {{- if .Values.opencost.customPricing.enabled }}
             - mountPath: {{ .Values.opencost.customPricing.configPath }}
               name: custom-configs
+              subPath: {{ include "opencost.configFileName" . }}.json
+              readOnly: true
+            {{- end }}
+            {{- if .Values.opencost.metrics.config.enabled }}
+            - mountPath: {{ .Values.opencost.customPricing.configPath }}
+              name: custom-metrics
+              subPath: metrics.json
               readOnly: true
             {{- end }}
             {{- if .Values.opencost.cloudIntegrationSecret }}
@@ -362,6 +369,11 @@ spec:
         - name: custom-configs
           configMap:
             name: {{ .Values.opencost.customPricing.configmapName }}
+        {{- end }}
+        {{- if .Values.opencost.metrics.config.enabled }}
+        - name: custom-metrics
+          configMap:
+            name: {{ .Values.opencost.config.metrics.configmapName }}
         {{- end }}
         {{- if .Values.opencost.exporter.persistence.enabled }}
         - name: opencost-export

--- a/charts/opencost/values.yaml
+++ b/charts/opencost/values.yaml
@@ -301,6 +301,8 @@ opencost:
     config:
       # -- Enables creating the metrics.json configuration as a ConfigMap
       enabled: false
+      # -- Customize the configmap name used for metrics
+      configmapName: custom-metrics
       # -- List of metrics to be disabled
       disabledMetrics: []
       # - <metric-to-be-disabled>


### PR DESCRIPTION
CONFIG_PATH is a single directory where both the custom pricing (`aws.json`) and `metrics.json` need to exist.

The only way to map multiple ConfigMaps into a single folder is to use subPath, so both `ConfigMap` volume mounts now use `subPath`.

This also unifies the way the names of the custom pricing and metrics configmap names are configured to follow the way the custom pricing one works.

This is a fix for the original change in https://github.com/opencost/opencost-helm-chart/pull/183

