### PR TITLE
Fix error when loading custom pricing configuration file 

### DIFF
--- a/charts/opencost/Chart.yaml
+++ b/charts/opencost/Chart.yaml
@@ -9,7 +9,7 @@ keywords:
   - finops
   - monitoring
   - opencost
-version: 1.37.0
+version: 1.38.0
 maintainers:
   - name: mattray
     url: https://mattray.dev

--- a/charts/opencost/templates/deployment.yaml
+++ b/charts/opencost/templates/deployment.yaml
@@ -243,7 +243,7 @@ spec:
               readOnly: false
             {{- end }}
             {{- if .Values.opencost.customPricing.enabled }}
-            - mountPath: {{ .Values.opencost.customPricing.configPath }}
+            - mountPath: {{ .Values.opencost.customPricing.configPath }}/{{ include "opencost.configFileName" . }}.json
               name: custom-configs
               subPath: {{ include "opencost.configFileName" . }}.json
               readOnly: true


### PR DESCRIPTION
This fixes the bug I reported in https://github.com/opencost/opencost-helm-chart/issues/205, where the `CONFIG_PATH` directory is mounted as a file instead of as a directory:

```
~ $ ls /tmp/custom-config -l
-rw-r--r--    1 root     root           299 May 15 10:27 /tmp/custom-config
~ $ cat /tmp/custom-config 
{
  "CPU": "1.25",
  "GPU": "0.95",
  "RAM": "0.5",
  "description": "Modified pricing configuration.",
  "internetNetworkEgress": "0.12",
  "regionNetworkEgress": "0.01",
  "spotCPU": "0.006655",
  "spotRAM": "0.000892",
  "storage": "0.25",
  "zoneNetworkEgress": "0.01",
  "provider" : "custom"
}~ $
```

This causes the pod to fail with:

```
opencost 2024-05-15T10:27:58.127897889Z ERR error accessing cloud provider configuration: stat /tmp/custom-config/default.json: not a directory
```