### PR TITLE
fix: namspace label key in selectors for netpol

### DIFF
--- a/charts/opencost/templates/networkpolicy.yaml
+++ b/charts/opencost/templates/networkpolicy.yaml
@@ -24,7 +24,7 @@ spec:
         {{- if ne .Values.networkPolicies.prometheus.namespace .Release.Namespace }}
         namespaceSelector:
           matchLabels:
-            name: {{ .Values.networkPolicies.prometheus.namespace }}
+            kubernetes.io/metadata.name: {{ .Values.networkPolicies.prometheus.namespace }}
         {{- end }}
       ports:
       - port: 9003
@@ -38,7 +38,7 @@ spec:
         {{- if ne .Values.networkPolicies.prometheus.namespace .Release.Namespace }}
         namespaceSelector:
           matchLabels:
-            name: {{ .Values.networkPolicies.prometheus.namespace }}
+            kubernetes.io/metadata.name: {{ .Values.networkPolicies.prometheus.namespace }}
         {{- end }}
       ports:
       - port: {{ .Values.networkPolicies.prometheus.port }}


### PR DESCRIPTION
Currently, the namespace label selector in the NetworkPolicies that will be created by setting the value `networkPolicies.enabled` to `true` is not set properly. The key of the namespace selector in the egress and ingress definition is `name` but should be `kubernetes.io/metadata.name`.
The [kubenetes docs](https://kubernetes.io/docs/reference/labels-annotations-taints/#kubernetes-io-metadata-name) state that the label `kubernetes.io/metadata.name` is set automatically and the `name` label is not compulsorily existing.