### PR TITLE
Fixes missing inclusion of subpath for the mount path

### DIFF
--- a/charts/opencost/Chart.yaml
+++ b/charts/opencost/Chart.yaml
@@ -9,7 +9,7 @@ keywords:
   - finops
   - monitoring
   - opencost
-version: 1.37.0
+version: 1.37.1
 maintainers:
   - name: mattray
     url: https://mattray.dev

--- a/charts/opencost/templates/deployment.yaml
+++ b/charts/opencost/templates/deployment.yaml
@@ -243,13 +243,13 @@ spec:
               readOnly: false
             {{- end }}
             {{- if .Values.opencost.customPricing.enabled }}
-            - mountPath: {{ .Values.opencost.customPricing.configPath }}
+            - mountPath: {{ .Values.opencost.customPricing.configPath }}/{{ include "opencost.configFileName" . }}.json
               name: custom-configs
               subPath: {{ include "opencost.configFileName" . }}.json
               readOnly: true
             {{- end }}
             {{- if .Values.opencost.metrics.config.enabled }}
-            - mountPath: {{ .Values.opencost.customPricing.configPath }}
+            - mountPath: {{ .Values.opencost.customPricing.configPath }}/metrics.json
               name: custom-metrics
               subPath: metrics.json
               readOnly: true
@@ -373,7 +373,7 @@ spec:
         {{- if .Values.opencost.metrics.config.enabled }}
         - name: custom-metrics
           configMap:
-            name: {{ .Values.opencost.config.metrics.configmapName }}
+            name: {{ .Values.opencost.metrics.config.configmapName }}
         {{- end }}
         {{- if .Values.opencost.exporter.persistence.enabled }}
         - name: opencost-export


### PR DESCRIPTION
A previous MR switched to using subpaths because we want to mount two different ConfigMaps into the same folder, however you have to include the filename in the `mountPath` and the `subPath` for this to work properly.

Fixes #205