### PR TITLE
Update version to fix CI

### DIFF
--- a/charts/opencost/Chart.yaml
+++ b/charts/opencost/Chart.yaml
@@ -9,7 +9,7 @@ keywords:
   - finops
   - monitoring
   - opencost
-version: 1.41.0
+version: 1.42.0
 maintainers:
   - name: mattray
     url: https://mattray.dev


### PR DESCRIPTION
The CI is failing because a PR was merged but the version of the chart was not updated.

This should fix the CI.