### PR TITLE
fix(artifacthub): push artifacthub-repo.yml file to oci repository (artifacthub/hub#3919)

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -67,8 +67,8 @@ jobs:
       - uses: oras-project/setup-oras@ca28077386065e263c03428f4ae0c09024817c93 # v1
         with:
           version: 1.2.0
-      - name: Push chart to GHCR
+      - name: Push oci metadata to GHCR
         run: |
-          oras push ghcr.io/"${GITHUB_REPOSITORY_OWNER}"/charts/opencost \
+          oras push ghcr.io/"${GITHUB_REPOSITORY_OWNER}"/charts/opencost:artifacthub.io \
           --config /dev/null:application/vnd.cncf.artifacthub.config.v1+yaml \
           artifacthub-repo.yml:application/vnd.cncf.artifacthub.repository-metadata.layer.v1.yaml


### PR DESCRIPTION
Fix, so that we get the following ArtifactHub badges for the OCI repository: 
- Verified publisher
- Official

Repo: https://artifacthub.io/packages/helm/opencost-oci/opencost