### PR TITLE
Add kubeRBACProxy property to support querying in cluster prometheus in openshift

### DIFF
--- a/charts/opencost/Chart.yaml
+++ b/charts/opencost/Chart.yaml
@@ -9,7 +9,7 @@ keywords:
   - finops
   - monitoring
   - opencost
-version: 1.42.4
+version: 1.43.0
 maintainers:
   - name: mattray
     url: https://mattray.dev

--- a/charts/opencost/Chart.yaml
+++ b/charts/opencost/Chart.yaml
@@ -9,7 +9,7 @@ keywords:
   - finops
   - monitoring
   - opencost
-version: 1.42.3
+version: 1.42.4
 maintainers:
   - name: mattray
     url: https://mattray.dev

--- a/charts/opencost/templates/_helpers.tpl
+++ b/charts/opencost/templates/_helpers.tpl
@@ -122,10 +122,10 @@ Check that either thanos external or internal is defined
 
 {{/*
   Fail if both kube-rbac-proxy and bearer token are set
-}}
+*/}}
 {{- define "kubeRBACProxyBearerTokenCheck" -}}
-{{- if and (.Values.opencost.prometheus.kubeRBACProxy .Values.opencost.prometheus.bearer_token) }}
-  {{- fail "\n\nBoth kubeRBACProxy and bearer_token are set. Please specify only one." -}}
+{{- if and .Values.opencost.prometheus.kubeRBACProxy .Values.opencost.prometheus.bearer_token }}
+  {{- fail "Both kubeRBACProxy and bearer_token are set. Please specify only one." -}}
 {{- end -}}
 {{- end -}}
 

--- a/charts/opencost/templates/_helpers.tpl
+++ b/charts/opencost/templates/_helpers.tpl
@@ -121,7 +121,7 @@ Check that either thanos external or internal is defined
 {{- end -}}
 
 {{/*
-  Verify if both kube-rbac-proxy and bearer token are set
+  Fail if both kube-rbac-proxy and bearer token are set
 }}
 {{- define "kubeRBACProxyBearerTokenCheck" -}}
 {{- if and (.Values.opencost.prometheus.kubeRBACProxy .Values.opencost.prometheus.bearer_token) }}

--- a/charts/opencost/templates/_helpers.tpl
+++ b/charts/opencost/templates/_helpers.tpl
@@ -121,6 +121,15 @@ Check that either thanos external or internal is defined
 {{- end -}}
 
 {{/*
+  Verify if both kube-rbac-proxy and bearer token are set
+}}
+{{- define "kubeRBACProxyBearerTokenCheck" -}}
+{{- if and (.Values.opencost.prometheus.kubeRBACProxy .Values.opencost.prometheus.bearer_token) }}
+  {{- fail "\n\nBoth kubeRBACProxy and bearer_token are set. Please specify only one." -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
 Check that the config is valid
 */}}
 {{- define "isPrometheusConfigValid" -}}

--- a/charts/opencost/templates/clusterrolebinding.yaml
+++ b/charts/opencost/templates/clusterrolebinding.yaml
@@ -15,4 +15,24 @@ subjects:
   - kind: ServiceAccount
     name: {{ template "opencost.serviceAccountName" . }}
     namespace: {{ include "opencost.namespace" . }}
+---
 {{- end }}
+{{- if .Values.opencost.prometheus.createPrometheusClusterRoleBinding }}
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: {{ include "opencost.fullname" . }}-operator
+  labels: {{- include "opencost.labels" . | nindent 4 }}
+  {{- with .Values.annotations }}
+  annotations: {{- toYaml . | nindent 4 }}
+  {{- end }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: cluster-monitoring-operator
+subjects:
+  - kind: ServiceAccount
+    name: {{ template "opencost.serviceAccountName" . }}
+    namespace: {{ include "opencost.namespace" . }}
+{{- end }}
+---

--- a/charts/opencost/templates/clusterrolebinding.yaml
+++ b/charts/opencost/templates/clusterrolebinding.yaml
@@ -27,8 +27,8 @@ metadata:
   annotations: {{- toYaml . | nindent 4 }}
   {{- end }}
 roleRef:
-  # Grant the kubecost service account the cluster-monitoring-view role to enable it to query OpenShift Prometheus.
-  # This is necessary for Kubecost to get access and query the in-cluster Prometheus instance using its service account token.
+  # Grant the OpenCost ServiceAccount the cluster-monitoring-view role to enable it to query a KUBE_RBAC_PROXY enabled Prometheus.
+  # This is necessary for OpenCost to get access and query the in-cluster Prometheus instance using its service account token.
   # https://docs.redhat.com/en/documentation/openshift_container_platform/4.2/html/monitoring/cluster-monitoring#monitoring-accessing-prometheus-alerting-ui-grafana-using-the-web-console_accessing-prometheus
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole

--- a/charts/opencost/templates/clusterrolebinding.yaml
+++ b/charts/opencost/templates/clusterrolebinding.yaml
@@ -17,7 +17,7 @@ subjects:
     namespace: {{ include "opencost.namespace" . }}
 ---
 {{- end }}
-{{- if .Values.opencost.prometheus.createPrometheusClusterRoleBinding }}
+{{- if .Values.opencost.prometheus.createMonitoringClusterRoleBinding }}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:

--- a/charts/opencost/templates/clusterrolebinding.yaml
+++ b/charts/opencost/templates/clusterrolebinding.yaml
@@ -27,9 +27,12 @@ metadata:
   annotations: {{- toYaml . | nindent 4 }}
   {{- end }}
 roleRef:
+  # Grant the kubecost service account the cluster-monitoring-view role to enable it to query OpenShift Prometheus.
+  # This is necessary for Kubecost to get access and query the in-cluster Prometheus instance using its service account token.
+  # https://docs.redhat.com/en/documentation/openshift_container_platform/4.2/html/monitoring/cluster-monitoring#monitoring-accessing-prometheus-alerting-ui-grafana-using-the-web-console_accessing-prometheus
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
-  name: cluster-monitoring-operator
+  name: cluster-monitoring-view
 subjects:
   - kind: ServiceAccount
     name: {{ template "opencost.serviceAccountName" . }}

--- a/charts/opencost/templates/deployment.yaml
+++ b/charts/opencost/templates/deployment.yaml
@@ -1,4 +1,5 @@
 {{- include  "isPrometheusConfigValid" . }}
+{{- include  "kubeRBACProxyBearerTokenCheck" . }}
 apiVersion: apps/v1
 kind: Deployment
 metadata:

--- a/charts/opencost/templates/deployment.yaml
+++ b/charts/opencost/templates/deployment.yaml
@@ -167,7 +167,7 @@ spec:
                   key: {{ .Values.opencost.prometheus.bearer_token_key }}
             {{- end }}
             {{- if .Values.opencost.prometheus.kubeRBACProxy }}
-            - name: ENABLE_KUBE_RBAC_PROXY
+            - name: KUBE_RBAC_PROXY_ENABLED
               value: {{ (quote .Values.opencost.prometheus.kubeRBACProxy) }}
             {{- end }}
             {{- if and .Values.opencost.exporter.persistence.enabled .Values.opencost.exporter.csv_path }}

--- a/charts/opencost/templates/deployment.yaml
+++ b/charts/opencost/templates/deployment.yaml
@@ -166,6 +166,10 @@ spec:
                   name: {{ .Values.opencost.prometheus.existingSecretName | default (include "opencost.prometheus.secretname" .) }}
                   key: {{ .Values.opencost.prometheus.bearer_token_key }}
             {{- end }}
+            {{- if .Values.opencost.prometheus.kubeRbacProxy }}
+            - name: ENABLE_KUBE_RBAC_PROXY
+              value: {{ (quote .Values.opencost.prometheus.kubeRbacProxy) }}
+            {{- end }}
             {{- if and .Values.opencost.exporter.persistence.enabled .Values.opencost.exporter.csv_path }}
             - name: EXPORT_CSV_FILE
               value: {{ .Values.opencost.exporter.csv_path | quote }}

--- a/charts/opencost/templates/deployment.yaml
+++ b/charts/opencost/templates/deployment.yaml
@@ -166,9 +166,9 @@ spec:
                   name: {{ .Values.opencost.prometheus.existingSecretName | default (include "opencost.prometheus.secretname" .) }}
                   key: {{ .Values.opencost.prometheus.bearer_token_key }}
             {{- end }}
-            {{- if .Values.opencost.prometheus.kubeRbacProxy }}
+            {{- if .Values.opencost.prometheus.kubeRBACProxy }}
             - name: ENABLE_KUBE_RBAC_PROXY
-              value: {{ (quote .Values.opencost.prometheus.kubeRbacProxy) }}
+              value: {{ (quote .Values.opencost.prometheus.kubeRBACProxy) }}
             {{- end }}
             {{- if and .Values.opencost.exporter.persistence.enabled .Values.opencost.exporter.csv_path }}
             - name: EXPORT_CSV_FILE

--- a/charts/opencost/templates/monitoring-role-binding-template.yaml
+++ b/charts/opencost/templates/monitoring-role-binding-template.yaml
@@ -1,0 +1,15 @@
+{{- if (.Values.opencost.prometheus.createMonitoringResourceReaderRoleBinding) }}
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  namespace: {{ include "opencost.namespace" . }}
+  name: {{ include "opencost.fullname" . }}-reader
+subjects:
+- kind: ServiceAccount
+  name: {{ .Values.opencost.prometheus.monitoringServiceAccountName | quote }}
+  namespace: openshift-monitoring
+roleRef:
+  kind: Role
+  name: {{ include "opencost.fullname" . }}-reader
+  apiGroup: rbac.authorization.k8s.io
+{{- end -}}

--- a/charts/opencost/templates/monitoring-role-binding-template.yaml
+++ b/charts/opencost/templates/monitoring-role-binding-template.yaml
@@ -7,7 +7,7 @@ metadata:
 subjects:
 - kind: ServiceAccount
   name: {{ .Values.opencost.prometheus.monitoringServiceAccountName | quote }}
-  namespace: openshift-monitoring
+  namespace: {{ .Values.opencost.prometheus.monitoringServiceAccountNamespace | quote }}
 roleRef:
   kind: Role
   name: {{ include "opencost.fullname" . }}-reader

--- a/charts/opencost/templates/monitoring-role-template.yaml
+++ b/charts/opencost/templates/monitoring-role-template.yaml
@@ -1,0 +1,17 @@
+{{- if (.Values.opencost.prometheus.createMonitoringResourceReaderRoleBinding) }}
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  namespace: {{ include "opencost.namespace" . }}
+  name: {{ include "opencost.fullname" . }}-reader
+rules:
+  - apiGroups: 
+      - ''
+    resources:
+      - "pods"
+      - "services"
+      - "endpoints"
+    verbs:
+      - list
+      - watch
+{{- end -}}

--- a/charts/opencost/values.yaml
+++ b/charts/opencost/values.yaml
@@ -335,13 +335,15 @@ opencost:
     bearer_token_key: DB_BEARER_TOKEN
     # -- If true, opencost will use kube-rbac-proxy to authenticate with in cluster Prometheus for openshift
     kubeRBACProxy: false
-    # -- If true, opencost will create a ClusterRoleBinding to allow using in-cluster Prometheus for openshift
+    # OPTIONAL. The following configs only to be enabled when using a Prometheus instance already installed in the cluster.
+    # -- If true, opencost will create a ClusterRoleBinding to grant the Kubecost serviceaccount access to query Prometheus.
     createMonitoringClusterRoleBinding: false
-    # -- If true, opencost will create a role and role binding to allow in-cluster prometheus to list and watch resources
-    # This will be necessary if you are not using bundled prometheus and need to add scrape config for resources.
+    # -- If true, opencost will rreate a Role and Role Binding to allow Prometheus to list and watch Kubecost resources.
     createMonitoringResourceReaderRoleBinding: false
-    # -- Name of the service account to bind to the ClusterRoleBinding
+    # -- Name of the Prometheus serviceaccount to bind to the Resource Reader Role Binding.
     monitoringServiceAccountName: prometheus-k8s
+    # -- Namespace of the Prometheus serviceaccount to bind to the Resource Reader Role Binding.
+    monitoringServiceAccountNamespace: openshift-monitoring
     external:
       # -- Use external Prometheus (eg. Grafana Cloud)
       enabled: false

--- a/charts/opencost/values.yaml
+++ b/charts/opencost/values.yaml
@@ -126,11 +126,11 @@ opencost:
     defaultClusterId: 'default-cluster'
     image:
       # -- Exporter container image registry
-      registry: ghcr.io
+      registry: docker.io
       # -- Exporter container image name
-      repository: opencost/opencost
+      repository: ishaanmittal/opencost
       # -- Exporter container image tag
-      tag: "1.111.0@sha256:6aa68e52a24b14ba41f23db08d1b9db1429a1c0300f4c0381ecc2c61fc311a97"
+      tag: "test-amd64"
       # -- Exporter container image pull policy
       pullPolicy: IfNotPresent
       # -- Override the full image name for development purposes
@@ -333,6 +333,10 @@ opencost:
     # -- Prometheus Bearer token
     bearer_token: ""
     bearer_token_key: DB_BEARER_TOKEN
+    # -- If true, opencost will use kube-rbac-proxy to authenticate with in cluster Prometheus for openshift
+    kubeRBACProxy: false
+    # -- If true, opencost will create a ClusterRoleBinding to allow using in-cluster Prometheus for openshift
+    createPrometheusClusterRoleBinding: false
     external:
       # -- Use external Prometheus (eg. Grafana Cloud)
       enabled: false
@@ -369,15 +373,14 @@ opencost:
     # -- Enable OpenCost UI
     enabled: true
     image:
-      # -- UI container image registry
-      registry: ghcr.io
-      # -- UI container image name
-      repository: opencost/opencost-ui
-      # -- UI container image tag
-      # @default -- `""` (use appVersion in Chart.yaml)
-      tag: "1.111.0@sha256:f7221e7a708d71663f5eca6c238268757eb4352f3e9f46b1029d33ab4e53fd8a"
+      # -- Exporter container image registry
+      registry: docker.io
+      # -- Exporter container image name
+      repository: ishaanmittal/opencost-ui
+      # -- Exporter container image tag
+      tag: "test-amd64"
       # -- UI container image pull policy
-      pullPolicy: IfNotPresent
+      pullPolicy: Always
       # -- Override the full image name for development purposes
       fullImageName: null
     resources:

--- a/charts/opencost/values.yaml
+++ b/charts/opencost/values.yaml
@@ -336,9 +336,9 @@ opencost:
     # -- If true, opencost will use kube-rbac-proxy to authenticate with in cluster Prometheus for openshift
     kubeRBACProxy: false
     # OPTIONAL. The following configs only to be enabled when using a Prometheus instance already installed in the cluster.
-    # -- If true, opencost will create a ClusterRoleBinding to grant the Kubecost serviceaccount access to query Prometheus.
+    # -- If true, the helm chart will create a ClusterRoleBinding to grant the OpenCost ServiceAccount access to query Prometheus.
     createMonitoringClusterRoleBinding: false
-    # -- If true, opencost will rreate a Role and Role Binding to allow Prometheus to list and watch Kubecost resources.
+    # -- If true, create a Role and RoleBinding to allow Prometheus to list and watch OpenCost resources.
     createMonitoringResourceReaderRoleBinding: false
     # -- Name of the Prometheus serviceaccount to bind to the Resource Reader Role Binding.
     monitoringServiceAccountName: prometheus-k8s

--- a/charts/opencost/values.yaml
+++ b/charts/opencost/values.yaml
@@ -126,11 +126,11 @@ opencost:
     defaultClusterId: 'default-cluster'
     image:
       # -- Exporter container image registry
-      registry: docker.io
+      registry: ghcr.io
       # -- Exporter container image name
-      repository: ishaanmittal/opencost
+      repository: opencost/opencost
       # -- Exporter container image tag
-      tag: "test-amd64"
+      tag: "1.111.0@sha256:6aa68e52a24b14ba41f23db08d1b9db1429a1c0300f4c0381ecc2c61fc311a97"
       # -- Exporter container image pull policy
       pullPolicy: IfNotPresent
       # -- Override the full image name for development purposes
@@ -336,7 +336,12 @@ opencost:
     # -- If true, opencost will use kube-rbac-proxy to authenticate with in cluster Prometheus for openshift
     kubeRBACProxy: false
     # -- If true, opencost will create a ClusterRoleBinding to allow using in-cluster Prometheus for openshift
-    createPrometheusClusterRoleBinding: false
+    createMonitoringClusterRoleBinding: false
+    # -- If true, opencost will create a role and role binding to allow in-cluster prometheus to list and watch resources
+    # This will be necessary if you are not using bundled prometheus and need to add scrape config for resources.
+    createMonitoringResourceReaderRoleBinding: false
+    # -- Name of the service account to bind to the ClusterRoleBinding
+    monitoringServiceAccountName: prometheus-k8s
     external:
       # -- Use external Prometheus (eg. Grafana Cloud)
       enabled: false
@@ -373,14 +378,15 @@ opencost:
     # -- Enable OpenCost UI
     enabled: true
     image:
-      # -- Exporter container image registry
-      registry: docker.io
-      # -- Exporter container image name
-      repository: ishaanmittal/opencost-ui
-      # -- Exporter container image tag
-      tag: "test-amd64"
+      # -- UI container image registry
+      registry: ghcr.io
+      # -- UI container image name
+      repository: opencost/opencost-ui
+      # -- UI container image tag
+      # @default -- `""` (use appVersion in Chart.yaml)
+      tag: "1.111.0@sha256:f7221e7a708d71663f5eca6c238268757eb4352f3e9f46b1029d33ab4e53fd8a"
       # -- UI container image pull policy
-      pullPolicy: Always
+      pullPolicy: IfNotPresent
       # -- Override the full image name for development purposes
       fullImageName: null
     resources:


### PR DESCRIPTION
* Add `kubeRBACProxy` property to set `KUBE_RBAC_PROXY_ENABLED` as true in the env var of the container.
* `createPrometheusClusterRoleBinding` property to create cluster role binding to grant required permissions to the serviceaccount to query prometheus with [kube-rbac-proxy](https://catalog.redhat.com/software/containers/rhacm2/kube-rbac-proxy-rhel8/611d4320eb34b73652492bb8) enabled. 
* Add the role binding to grant permissions this external prometheus to scrape metrics from kubecost. 
* Add fail if both `kubeRBACProxy` and `BearerToken` property cannot be set together.

Testing:
deployed opencost in openshift cluster using in cluster prometheus. We were able to query the prometheus.
```sh
2024-12-06T19:03:40.832625335Z INF Prometheus/Thanos Client Max Concurrency set to 5                                                                                                       2024-12-06T19:03:41.881115203Z INF Success: retrieved the 'up' query against prometheus at: https://prometheus-k8s.openshift-monitoring.svc.cluster.local:9091                            
2024-12-06T19:03:41.882834227Z INF Retrieved a prometheus config file from: https://prometheus-k8s.openshift-monitoring.svc.cluster.local:9091                                             
2024-12-06T19:03:41.955015089Z INF Using scrape interval of 60.000000     
```