### PR TITLE
Fix typo in image.tag default values

### DIFF
--- a/charts/opencost/Chart.yaml
+++ b/charts/opencost/Chart.yaml
@@ -9,7 +9,7 @@ keywords:
   - finops
   - monitoring
   - opencost
-version: 1.42.1
+version: 1.42.2
 maintainers:
   - name: mattray
     url: https://mattray.dev

--- a/charts/opencost/values.yaml
+++ b/charts/opencost/values.yaml
@@ -130,7 +130,7 @@ opencost:
       # -- Exporter container image name
       repository: opencost/opencost
       # -- Exporter container image tag
-      tag: "1.112.1sha256:1be970e670d694329978b1c34129b07d04ff9504b4255c86998dfe281aea702e"
+      tag: "1.112.1@sha256:d3c56b0d6c3ded6513724cec8c777a2f4395a6ebde2d1fe27200a56112e3b9c3"
       # -- Exporter container image pull policy
       pullPolicy: IfNotPresent
       # -- Override the full image name for development purposes
@@ -375,7 +375,7 @@ opencost:
       repository: opencost/opencost-ui
       # -- UI container image tag
       # @default -- `""` (use appVersion in Chart.yaml)
-      tag: "1.112.1sha256:20dee8385678f4223afe920ee52a6572c13816cd82dcf846a068df587a2fdc1e"
+      tag: "1.112.1@sha256:e0234de00677253ed9ec96479ac470b51e1c1504e5dfb9e9e0983156533f25ef"
       # -- UI container image pull policy
       pullPolicy: IfNotPresent
       # -- Override the full image name for development purposes


### PR DESCRIPTION
- Return `@` before `sha256` in `opencost.image.tag` and `opencost.ui.image.tag`
- Fix `sha256` hashes

This fixes #233