### PR TITLE
Add clsuterName to support clusters with non-default names

### DIFF
--- a/charts/opencost/Chart.yaml
+++ b/charts/opencost/Chart.yaml
@@ -9,7 +9,7 @@ keywords:
   - finops
   - monitoring
   - opencost
-version: 1.43.1
+version: 1.43.2
 maintainers:
   - name: mattray
     url: https://mattray.dev

--- a/charts/opencost/templates/_helpers.tpl
+++ b/charts/opencost/templates/_helpers.tpl
@@ -101,8 +101,9 @@ Create the name of the controller service account to use
   {{- else -}}
     {{- $host := tpl .Values.opencost.prometheus.internal.serviceName . }}
     {{- $ns := tpl .Values.opencost.prometheus.internal.namespaceName . }}
+    {{- $clusterName := .Values.clusterName }}
     {{- $port := .Values.opencost.prometheus.internal.port | int }}
-    {{- printf "http://%s.%s.svc.cluster.local:%d" $host $ns $port -}}
+    {{- printf "http://%s.%s.svc.%s:%d" $host $ns $clusterName $port -}}
   {{- end -}}
 {{- end -}}
 
@@ -115,8 +116,9 @@ Check that either thanos external or internal is defined
   {{- else -}}
     {{- $host := .Values.opencost.prometheus.thanos.internal.serviceName }}
     {{- $ns := .Values.opencost.prometheus.thanos.internal.namespaceName }}
+    {{- $clusterName := .Values.clusterName }}
     {{- $port := .Values.opencost.prometheus.thanos.internal.port | int }}
-    {{- printf "http://%s.%s.svc.cluster.local:%d" $host $ns $port -}}
+    {{- printf "http://%s.%s.svc.%s:%d" $host $ns $clusterName $port -}}
   {{- end -}}
 {{- end -}}
 

--- a/charts/opencost/values.yaml
+++ b/charts/opencost/values.yaml
@@ -4,6 +4,8 @@ nameOverride: ""
 fullnameOverride: ""
 # -- Override the deployment namespace
 namespaceOverride: ""
+# -- Override the default name of cluster - Can be found in /etc/kubernetes/admin.conf: clusters -> cluster -> name
+clusterName: "cluster.local"
 
 loglevel: info
 


### PR DESCRIPTION
By adding clusterName to values, you can install OpenCost in clusters with names other than cluster.local and connect to Prometheus correctly.

This fixes #235 