### PR TITLE
allow creating an OpenShift route

### DIFF
--- a/charts/opencost/Chart.yaml
+++ b/charts/opencost/Chart.yaml
@@ -9,7 +9,7 @@ keywords:
   - finops
   - monitoring
   - opencost
-version: 1.44.0
+version: 1.45.0
 maintainers:
   - name: jessegoodier
   - name: toscott

--- a/charts/opencost/templates/route.yaml
+++ b/charts/opencost/templates/route.yaml
@@ -1,4 +1,4 @@
-{{- if and .Capabilities.APIVersions.Has "route.openshift.io/v1/Route" .Values.opencost.ui.enabled .Values.opencost.ui.route.enabled }}
+{{- if and (.Capabilities.APIVersions.Has "route.openshift.io/v1/Route") .Values.opencost.ui.enabled .Values.opencost.ui.route.enabled }}
 apiVersion: route.openshift.io/v1
 kind: Route
 metadata:

--- a/charts/opencost/templates/route.yaml
+++ b/charts/opencost/templates/route.yaml
@@ -1,0 +1,32 @@
+{{- if and .Values.opencost.ui.enabled .Values.opencost.ui.route.enabled }}
+apiVersion: route.openshift.io/v1
+kind: Route
+metadata:
+  name: {{ include "opencost.fullname" . }}-route
+  namespace: {{ include "opencost.namespace" . }}
+  labels: {{- include "opencost.labels" . | nindent 4 }}
+  {{- with .Values.opencost.ui.route.annotations }}
+  annotations: {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  host: {{ .Values.opencost.ui.route.host | quote }}
+  {{- if .Values.opencost.ui.route.path }}
+  path: {{ .Values.opencost.ui.route.path }}
+  {{- end }}
+  port:
+    targetPort: {{ .Values.opencost.ui.route.targetPort }}
+  to:
+    kind: Service
+    name: opencost
+    weight: 100
+  wildcardPolicy: None
+  {{- if .Values.opencost.ui.route.tls }}
+  tls:
+    {{- if .Values.opencost.ui.route.tls.insecureEdgeTerminationPolicy }}
+    insecureEdgeTerminationPolicy: {{ .Values.opencost.ui.route.tls.insecureEdgeTerminationPolicy }}
+    {{- end }}
+    {{- if .Values.opencost.ui.route.tls.termination }}
+    termination: {{ .Values.opencost.ui.route.tls.termination }}
+    {{- end }}
+  {{- end }}
+{{- end }}

--- a/charts/opencost/templates/route.yaml
+++ b/charts/opencost/templates/route.yaml
@@ -1,4 +1,4 @@
-{{- if and .Values.opencost.ui.enabled .Values.opencost.ui.route.enabled }}
+{{- if and .Capabilities.APIVersions.Has "route.openshift.io/v1/Route" .Values.opencost.ui.enabled .Values.opencost.ui.route.enabled }}
 apiVersion: route.openshift.io/v1
 kind: Route
 metadata:
@@ -17,7 +17,7 @@ spec:
     targetPort: {{ .Values.opencost.ui.route.targetPort }}
   to:
     kind: Service
-    name: opencost
+    name: {{ include "opencost.fullname" . }}
     weight: 100
   wildcardPolicy: None
   {{- if .Values.opencost.ui.route.tls }}

--- a/charts/opencost/values.yaml
+++ b/charts/opencost/values.yaml
@@ -466,6 +466,22 @@ opencost:
         #  - secretName: chart-example-tls
         #    hosts:
         #      - chart-example.local
+    route:
+      # -- OpenShift route for OpenCost UI
+      enabled: false
+      # -- Annotations for Ingress resource
+      annotations: {}
+        # haproxy.router.openshift.io/timeout: 1m
+      # @default -- See [values.yaml](values.yaml)
+      host: example.local
+      path:
+      # -- Redirect ingress to an extraPort defined on the service such as oauth-proxy
+      targetPort: http-ui
+      # targetPort: oauth-proxy
+      # -- Ingress TLS configuration
+      tls: []
+        # insecureEdgeTerminationPolicy: Redirect
+        # termination: edge
 
   sigV4Proxy:
     image: public.ecr.aws/aws-observability/aws-sigv4-proxy:latest


### PR DESCRIPTION
This is **not** meant as a PR ready to merge. I just wanted to start a discussion, if the functionality to create an OpenShift route via the helm chart would be something worth adding.

I know the chart can create an ingress, but if you want to put OpenCost behind a oauth-proxy, you need to put the route name into an annotation on the `serviceAccount`. And if the route is being created from an ingress automatically, its name contains a random hash...