### PR TITLE
bump OC to 1.114

### DIFF
--- a/charts/opencost/Chart.yaml
+++ b/charts/opencost/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v2
-appVersion: 1.113.0
+appVersion: 1.114.0
 name: opencost
 description: OpenCost and OpenCost UI
 type: application
@@ -9,7 +9,7 @@ keywords:
   - finops
   - monitoring
   - opencost
-version: 1.43.2
+version: 1.44.0
 maintainers:
   - name: mattray
     url: https://mattray.dev

--- a/charts/opencost/values.yaml
+++ b/charts/opencost/values.yaml
@@ -132,7 +132,7 @@ opencost:
       # -- Exporter container image name
       repository: opencost/opencost
       # -- Exporter container image tag
-      tag: "1.113.0@sha256:b313d6d320058bbd3841a948fb636182f49b46df2368d91e2ae046ed03c0f83c"
+      tag: "1.114.0@sha256:e0e6d87827559544d19d0096f3a0c0a62e2bcac4479031f7849f3ee823ad19fb"
       # -- Exporter container image pull policy
       pullPolicy: IfNotPresent
       # -- Override the full image name for development purposes
@@ -388,7 +388,7 @@ opencost:
       repository: opencost/opencost-ui
       # -- UI container image tag
       # @default -- `""` (use appVersion in Chart.yaml)
-      tag: "1.113.0@sha256:4f408cf765217f889f4cb5cfcc97356e09892045a6ec951b27817a42ecb6748d"
+      tag: "1.114.0@sha256:09edc15c5f917c82a8a10f840595e7f3768e767546c19f05c2364378aa9883e0"
       # -- UI container image pull policy
       pullPolicy: IfNotPresent
       # -- Override the full image name for development purposes


### PR DESCRIPTION
increments opencost to 1.114 version, bumps app version as well 