### PR TITLE
update chart version and app version

### DIFF
--- a/charts/opencost/README.md
+++ b/charts/opencost/README.md
@@ -2,9 +2,9 @@
 
 OpenCost and OpenCost UI
 
-![Version: 1.40.0](https://img.shields.io/badge/Version-1.40.0-informational?style=flat-square)
+![Version: 1.44.0](https://img.shields.io/badge/Version-1.44.0-informational?style=flat-square)
 ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
-![AppVersion: 1.112.1](https://img.shields.io/badge/AppVersion-1.112.1-informational?style=flat-square)
+![AppVersion: 1.114.0](https://img.shields.io/badge/AppVersion-1.114.0-informational?style=flat-square)
 [![Artifact Hub](https://img.shields.io/endpoint?url=https://artifacthub.io/badge/repository/opencost)](https://artifacthub.io/packages/search?repo=opencost)
 [![Artifact Hub](https://img.shields.io/endpoint?url=https://artifacthub.io/badge/repository/opencost-oci)](https://artifacthub.io/packages/search?repo=opencost-oci)
 


### PR DESCRIPTION
Addresses issue https://github.com/opencost/opencost-helm-chart/issues/246
Though this fixes only the latest readme, certain version readmes still remain outdated.