### PR TITLE
feat(parquet-exporter): use appVersion in Chart.yaml as default tag for container image

### DIFF
--- a/charts/opencost-parquet-exporter/Chart.yaml
+++ b/charts/opencost-parquet-exporter/Chart.yaml
@@ -15,12 +15,12 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.1.0
+version: 0.2.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "1.16.0"
+appVersion: "0.2.1"
 maintainers:
   - name: cklingspor

--- a/charts/opencost-parquet-exporter/templates/_helpers.tpl
+++ b/charts/opencost-parquet-exporter/templates/_helpers.tpl
@@ -31,6 +31,17 @@ Create chart name and version as used by the chart label.
 {{- end }}
 
 {{/*
+Create default image tag taken from the AppVersion.
+*/}}
+{{- define "opencost-parquet-exporter.imageTag" -}}
+{{ .Values.image.tag | default (printf "v%s" .Chart.AppVersion) }}
+{{- end }}
+
+{{- define "opencost-parquet-exporter.fullImageName" -}}
+{{ .Values.image.repository -}}:{{ include "opencost-parquet-exporter.imageTag" . }}
+{{- end }}
+
+{{/*
 Common labels
 */}}
 {{- define "opencost-parquet-exporter.labels" -}}

--- a/charts/opencost-parquet-exporter/templates/_helpers.tpl
+++ b/charts/opencost-parquet-exporter/templates/_helpers.tpl
@@ -34,7 +34,7 @@ Create chart name and version as used by the chart label.
 Create default image tag taken from the AppVersion.
 */}}
 {{- define "opencost-parquet-exporter.imageTag" -}}
-{{ .Values.image.tag | default (printf "%s" .Chart.AppVersion) }}
+{{ .Values.image.tag | default (printf "v%s" .Chart.AppVersion) }}
 {{- end }}
 
 {{- define "opencost-parquet-exporter.fullImageName" -}}

--- a/charts/opencost-parquet-exporter/templates/_helpers.tpl
+++ b/charts/opencost-parquet-exporter/templates/_helpers.tpl
@@ -34,7 +34,7 @@ Create chart name and version as used by the chart label.
 Create default image tag taken from the AppVersion.
 */}}
 {{- define "opencost-parquet-exporter.imageTag" -}}
-{{ .Values.image.tag | default (printf "v%s" .Chart.AppVersion) }}
+{{ .Values.image.tag | default (printf "%s" .Chart.AppVersion) }}
 {{- end }}
 
 {{- define "opencost-parquet-exporter.fullImageName" -}}

--- a/charts/opencost-parquet-exporter/templates/cronjob.yaml
+++ b/charts/opencost-parquet-exporter/templates/cronjob.yaml
@@ -45,7 +45,7 @@ spec:
           securityContext: {}
           {{- end }}
           containers:
-            - image: {{ .Values.image.repository }}:{{ .Values.image.tag }}
+            - image: {{ include "opencost-parquet-exporter.fullImageName" . }}
               imagePullPolicy: {{ .Values.image.imagePullPolicy }}
               name: {{ include "opencost-parquet-exporter.name" $ }} 
               {{- with .Values.resources }}

--- a/charts/opencost-parquet-exporter/values.yaml
+++ b/charts/opencost-parquet-exporter/values.yaml
@@ -24,7 +24,8 @@ securityContext:
     - ALL
 image:
   repository: ghcr.io/opencost/opencost-parquet-exporter
-  tag: main
+  # @default -- `""` (use appVersion in Chart.yaml)
+  tag: ""
   imagePullPolicy: Always
 # -- List of env vars
 env:


### PR DESCRIPTION
This PR aims at using the appVersion defined in Chart.yaml as the default container image rather than using "main". (Same as the opencost helm chart).

It also sets the appVersion to 0.2.1, as it is the [latest release](https://github.com/opencost/opencost-parquet-exporter/releases/tag/v0.2.1) of the exporter

Close #259 