### PR TITLE
charts/opencost/values.yaml: remove CPU limits

### DIFF
--- a/charts/opencost/Chart.yaml
+++ b/charts/opencost/Chart.yaml
@@ -9,7 +9,7 @@ keywords:
   - finops
   - monitoring
   - opencost
-version: 1.44.0
+version: 1.44.1
 maintainers:
   - name: jessegoodier
   - name: toscott

--- a/charts/opencost/values.yaml
+++ b/charts/opencost/values.yaml
@@ -148,7 +148,6 @@ opencost:
         memory: '55Mi'
       # -- CPU/Memory resource limits
       limits:
-        cpu: '999m'
         memory: '1Gi'
     # Startup probe configuration
     startupProbe:
@@ -400,7 +399,6 @@ opencost:
         memory: '55Mi'
       # -- CPU/Memory resource limits
       limits:
-        cpu: '999m'
         memory: '1Gi'
     # used in the default.nginx.conf if you want to switch for using with Docker
     # apiServer: 0.0.0.0


### PR DESCRIPTION
Setting CPU limits is no longer recommended, see
https://home.robusta.dev/blog/stop-using-cpu-limits