### PR TITLE
Fix: Chart release script

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -51,7 +51,7 @@ jobs:
           config: './.github/configs/cr.yaml'
         env:
           CR_TOKEN: '${{ secrets.GITHUB_TOKEN }}'
-          CR_RELEASE_NAME_TEMPLATE: '{{ .Version }}-helm'
+          CR_SKIP_EXISTING: true
 
       - uses: sigstore/cosign-installer@59acb6260d9c0ba8f4a2f9d9b48431a222b68e20 # v3.5.0
       - name: Push chart to GHCR

--- a/charts/opencost/README.md
+++ b/charts/opencost/README.md
@@ -8,14 +8,6 @@ OpenCost and OpenCost UI
 [![Artifact Hub](https://img.shields.io/endpoint?url=https://artifacthub.io/badge/repository/opencost)](https://artifacthub.io/packages/search?repo=opencost)
 [![Artifact Hub](https://img.shields.io/endpoint?url=https://artifacthub.io/badge/repository/opencost-oci)](https://artifacthub.io/packages/search?repo=opencost-oci)
 
-## Maintainers
-
-| Name | Email | Url |
-| ---- | ------ | --- |
-| mattray |  | <https://mattray.dev> |
-| toscott |  |  |
-| brito-rafa | <rafa@stormforge.io> |  |
-
 ## Installing the Chart
 
 To install the chart with the release name `opencost`:


### PR DESCRIPTION
Fixes: https://github.com/opencost/opencost-helm-chart/issues/258
Removed the `CR_RELEASE_NAME_TEMPLATE` having `version-helm` as with multiple charts we can having conflicts.
removing it would default to `name-version`
Added `CR_SKIP_EXISTING` to skip existing charts that did not have a version bump similar to https://github.com/helm/chart-releaser/pull/111#issue-830518351