### PR TITLE
allow: set path for internal prometheus

### DIFF
--- a/charts/opencost/README.md
+++ b/charts/opencost/README.md
@@ -118,6 +118,7 @@ $ helm install opencost opencost/opencost
 | opencost.prometheus.internal.namespaceName | string | `"prometheus-system"` | Namespace of in-cluster Prometheus |
 | opencost.prometheus.internal.port | int | `80` | Service port of in-cluster Prometheus |
 | opencost.prometheus.internal.serviceName | string | `"prometheus-server"` | Service name of in-cluster Prometheus |
+| opencost.prometheus.internal.path | string | `""` | Set path to prometheus if behind reverse proxy(mimir) |
 | opencost.prometheus.password | string | `""` | Prometheus Basic auth password |
 | opencost.prometheus.password_key | string | `"DB_BASIC_AUTH_PW"` | Key in the secret that references the password |
 | opencost.prometheus.secret_name | string | `nil` | Secret name that contains credentials for Prometheus |

--- a/charts/opencost/templates/_helpers.tpl
+++ b/charts/opencost/templates/_helpers.tpl
@@ -98,13 +98,18 @@ Create the name of the controller service account to use
     {{- $port := .Values.opencost.sigV4Proxy.port | int }}
     {{- $ws := .Values.opencost.prometheus.amp.workspaceId }}
     {{- printf "http://localhost:%d/workspaces/%v" $port $ws -}}
-  {{- else -}}
+{{- else -}}
     {{- $host := tpl .Values.opencost.prometheus.internal.serviceName . }}
     {{- $ns := tpl .Values.opencost.prometheus.internal.namespaceName . }}
     {{- $clusterName := .Values.clusterName }}
     {{- $port := .Values.opencost.prometheus.internal.port | int }}
-    {{- printf "http://%s.%s.svc.%s:%d" $host $ns $clusterName $port -}}
-  {{- end -}}
+    {{- $path := .Values.opencost.prometheus.internal.path | default "" }}
+    {{- if $path }}
+      {{- printf "http://%s.%s.svc.%s:%d%s" $host $ns $clusterName $port $path -}}
+    {{- else }}
+      {{- printf "http://%s.%s.svc.%s:%d" $host $ns $clusterName $port -}}
+    {{- end }}
+{{- end -}}
 {{- end -}}
 
 {{/*

--- a/charts/opencost/values.yaml
+++ b/charts/opencost/values.yaml
@@ -350,6 +350,8 @@ opencost:
       namespaceName: prometheus-system
       # -- Service port of in-cluster Prometheus
       port: 80
+      # -- Path to access the Prometheus API, this is neccesary if the Prometheus server is behind a reverse proxy(mimir) or has a different path.
+      path: ""
     amp:
       # -- Use Amazon Managed Service for Prometheus (AMP)
       enabled: false  # If true, opencost will be configured to remote_write and query from Amazon Managed Service for Prometheus.


### PR DESCRIPTION
When querying prometheus  behind a reverse proxy such as [The mimir-query-frontend](https://grafana.com/docs/mimir/latest/references/architecture/components/query-frontend/) we need to specify the path to prometheus.
ie /prometheus
If prometheus is external then you can set it in the url:
opencost.prometheus.external.url: https://example.com/prometheus
But if you are querying prometheus in the cluster there currently is no option.
This PR resolves that issue by allowing it to be set here -> opencost.prometheus.internal.path