### PR TITLE
Add opencost.ui.useIPv6 feature flag

### DIFF
--- a/charts/opencost/Chart.yaml
+++ b/charts/opencost/Chart.yaml
@@ -9,7 +9,7 @@ keywords:
   - finops
   - monitoring
   - opencost
-version: 2.0.1
+version: 2.1.0
 maintainers:
   - name: jessegoodier
   - name: toscott

--- a/charts/opencost/Chart.yaml
+++ b/charts/opencost/Chart.yaml
@@ -9,7 +9,7 @@ keywords:
   - finops
   - monitoring
   - opencost
-version: 2.1.0
+version: 2.0.2
 maintainers:
   - name: jessegoodier
   - name: toscott

--- a/charts/opencost/README.md
+++ b/charts/opencost/README.md
@@ -176,6 +176,7 @@ $ helm install opencost opencost/opencost
 | opencost.ui.resources.requests | object | `{"cpu":"10m","memory":"55Mi"}` | CPU/Memory resource requests |
 | opencost.ui.securityContext | object | `{}` | The security options the container should be run with |
 | opencost.ui.uiPort | int | `9090` |  |
+| opencost.ui.useIPv6 | bool | `true` |  |
 | opencost.ui.useDefaultFqdn | bool | false | To use `<service>.<namespace>.svc.cluster.local` or `<service>.<namespace>` |
 | opencost.ui.modelFqdn | string | `nil` | Set the model fqdn to use for the upstream |
 | plugins.configs | string | `nil` |  |

--- a/charts/opencost/templates/configmap-frontend.yaml
+++ b/charts/opencost/templates/configmap-frontend.yaml
@@ -72,7 +72,9 @@ data:
 
         add_header ETag "1.96.0";
         listen {{ .Values.opencost.ui.uiPort }};
+        {{- if .Values.opencost.ui.useIPv6 | default true }}
         listen [::]:{{ .Values.opencost.ui.uiPort }};
+        {{- end }}
         resolver 127.0.0.1 valid=5s;
         location /healthz {
             access_log /dev/null;

--- a/charts/opencost/values.yaml
+++ b/charts/opencost/values.yaml
@@ -394,6 +394,8 @@ opencost:
     # used in the default.nginx.conf if you want to switch for using with Docker
     # apiServer: 0.0.0.0
     uiPort: 9090
+    # Set to true to use IPv6
+    useIPv6: true
     # Liveness probe configuration
     livenessProbe:
       # -- Whether probe is enabled


### PR DESCRIPTION
Currently errors are thrown when the nginx is unable to bind to an IPv6 address. This needs to be disabled for clusters where IPv6 is disabled.

I've added a flag that defaults to true for this setting so it's backwards compatibly but allows disabling the IPv6 requirement.