### PR TITLE
feat(sec) - customize service account mounting

### DIFF
--- a/charts/opencost/Chart.yaml
+++ b/charts/opencost/Chart.yaml
@@ -9,7 +9,7 @@ keywords:
   - finops
   - monitoring
   - opencost
-version: 2.1.5
+version: 2.1.6
 maintainers:
   - name: jessegoodier
   - name: toscott

--- a/charts/opencost/README.md
+++ b/charts/opencost/README.md
@@ -2,11 +2,20 @@
 
 OpenCost and OpenCost UI
 
-![Version: 1.44.0](https://img.shields.io/badge/Version-1.44.0-informational?style=flat-square)
+![Version: 2.1.5](https://img.shields.io/badge/Version-2.1.5-informational?style=flat-square)
 ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
-![AppVersion: 1.114.0](https://img.shields.io/badge/AppVersion-1.114.0-informational?style=flat-square)
+![AppVersion: 1.115.0](https://img.shields.io/badge/AppVersion-1.115.0-informational?style=flat-square)
 [![Artifact Hub](https://img.shields.io/endpoint?url=https://artifacthub.io/badge/repository/opencost)](https://artifacthub.io/packages/search?repo=opencost)
 [![Artifact Hub](https://img.shields.io/endpoint?url=https://artifacthub.io/badge/repository/opencost-oci)](https://artifacthub.io/packages/search?repo=opencost-oci)
+
+## Maintainers
+
+| Name | Email | Url |
+| ---- | ------ | --- |
+| jessegoodier |  |  |
+| toscott |  |  |
+| mittal-ishaan |  |  |
+| brito-rafa | <rafa@stormforge.io> |  |
 
 ## Installing the Chart
 
@@ -21,6 +30,7 @@ $ helm install opencost opencost/opencost
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
 | annotations | object | `{}` | Annotations to add to the all the resources |
+| clusterName | string | `"cluster.local"` | Override the default name of cluster - Can be found in /etc/kubernetes/admin.conf: clusters -> cluster -> name |
 | extraVolumes | list | `[]` | A list of volumes to be added to the pod |
 | fullnameOverride | string | `""` | Overwrite all resources name created by the chart |
 | imagePullSecrets | list | `[]` | List of secret names to use for pulling the images |
@@ -48,9 +58,9 @@ $ helm install opencost opencost/opencost
 | opencost.customPricing.enabled | bool | `false` | Enables custom pricing configuration |
 | opencost.customPricing.provider | string | `"custom"` | Sets the provider type for the custom pricing file. |
 | opencost.dataRetention.dailyResolutionDays | int | `15` |  |
-| opencost.exporter.apiIngress.annotations | object | `{}` | Annotations for API Ingress resource |
+| opencost.exporter.apiIngress.annotations | object | `{}` | Annotations for Ingress resource |
 | opencost.exporter.apiIngress.enabled | bool | `false` | Ingress for OpenCost API |
-| opencost.exporter.apiIngress.hosts | list | See [values.yaml](values.yaml) | A list of host rules used to configure the API Ingress |
+| opencost.exporter.apiIngress.hosts | list | See [values.yaml](values.yaml) | A list of host rules used to configure the Ingress |
 | opencost.exporter.apiIngress.ingressClassName | string | `""` | Ingress controller which implements the resource |
 | opencost.exporter.apiIngress.servicePort | string | `"http"` | Redirect ingress to an extraPort defined on the service such as oauth-proxy |
 | opencost.exporter.apiIngress.tls | list | `[]` | Ingress TLS configuration |
@@ -58,6 +68,12 @@ $ helm install opencost opencost/opencost
 | opencost.exporter.aws.access_key_id | string | `""` | AWS secret key id |
 | opencost.exporter.aws.secret_access_key | string | `""` | AWS secret access key |
 | opencost.exporter.cloudProviderApiKey | string | `""` | The GCP Pricing API requires a key. This is supplied just for evaluation. |
+| opencost.exporter.collectorDataSource.enabled | bool | `false` |  |
+| opencost.exporter.collectorDataSource.networkPort | int | `3001` | The port at which network pods are open to egress |
+| opencost.exporter.collectorDataSource.retentionResolution10m | int | `36` | The number of 10m intervals the Collector DataSource should maintain |
+| opencost.exporter.collectorDataSource.retentionResolution1d | int | `15` | The number of 1d intervals the Collector DataSource should maintain |
+| opencost.exporter.collectorDataSource.retentionResolution1h | int | `49` | The number of 1h intervals the Collector DataSource should maintain |
+| opencost.exporter.collectorDataSource.scrapeInterval | string | `"30s"` | define the interval at which the collector scrapes for data points (10s, 15s, 1m) |
 | opencost.exporter.csv_path | string | `""` |  |
 | opencost.exporter.defaultClusterId | string | `"default-cluster"` | Default cluster ID to use if cluster_id is not set in Prometheus metrics. |
 | opencost.exporter.env | list | `[]` | List of additional environment variables to set in the container |
@@ -68,7 +84,7 @@ $ helm install opencost opencost/opencost
 | opencost.exporter.image.pullPolicy | string | `"IfNotPresent"` | Exporter container image pull policy |
 | opencost.exporter.image.registry | string | `"ghcr.io"` | Exporter container image registry |
 | opencost.exporter.image.repository | string | `"opencost/opencost"` | Exporter container image name |
-| opencost.exporter.image.tag | string | `""` (use appVersion in Chart.yaml) | Exporter container image tag |
+| opencost.exporter.image.tag | string | `"1.115.0@sha256:fb6468a1ef45dbd4a9e521122c8d306f882bb33d1657d28d21aeaef79412e9e1"` | Exporter container image tag |
 | opencost.exporter.livenessProbe.enabled | bool | `true` | Whether probe is enabled |
 | opencost.exporter.livenessProbe.failureThreshold | int | `3` | Number of failures for probe to be considered failed |
 | opencost.exporter.livenessProbe.initialDelaySeconds | int | `10` | Number of seconds before probe is initiated |
@@ -77,6 +93,7 @@ $ helm install opencost opencost/opencost
 | opencost.exporter.persistence.accessMode | string | `""` | Access mode for persistent volume |
 | opencost.exporter.persistence.annotations | object | `{}` | Annotations for persistent volume |
 | opencost.exporter.persistence.enabled | bool | `false` |  |
+| opencost.exporter.persistence.mountPath | string | `"/mnt/export"` | The path that the PV will be mounted to the exporter at |
 | opencost.exporter.persistence.size | string | `""` | Size for persistent volume |
 | opencost.exporter.persistence.storageClass | string | `""` | Storage class for persistent volume |
 | opencost.exporter.readinessProbe.enabled | bool | `true` | Whether probe is enabled |
@@ -85,7 +102,7 @@ $ helm install opencost opencost/opencost
 | opencost.exporter.readinessProbe.path | string | `"/healthz"` | Probe path |
 | opencost.exporter.readinessProbe.periodSeconds | int | `10` | Probe frequency in seconds |
 | opencost.exporter.replicas | int | `1` | Number of OpenCost replicas to run |
-| opencost.exporter.resources.limits | object | `{"cpu":"999m","memory":"1Gi"}` | CPU/Memory resource limits |
+| opencost.exporter.resources.limits | object | `{"memory":"1Gi"}` | CPU/Memory resource limits |
 | opencost.exporter.resources.requests | object | `{"cpu":"10m","memory":"55Mi"}` | CPU/Memory resource requests |
 | opencost.exporter.securityContext | object | `{}` | The security options the container should be run with |
 | opencost.exporter.startupProbe.enabled | bool | `true` | Whether probe is enabled |
@@ -113,6 +130,13 @@ $ helm install opencost opencost/opencost
 | opencost.metrics.serviceMonitor.scrapeTimeout | string | `"10s"` | Timeout after which the scrape is ended |
 | opencost.metrics.serviceMonitor.tlsConfig | object | `{}` | TLS configuration for scraping metrics |
 | opencost.nodeSelector | object | `{}` | Node labels for pod assignment |
+| opencost.platforms.openshift.createMonitoringClusterRoleBinding | bool | `false` | If true, the helm chart will create a ClusterRoleBinding to grant the OpenCost ServiceAccount access to query Prometheus. |
+| opencost.platforms.openshift.createMonitoringResourceReaderRoleBinding | bool | `false` | If true, create a Role and RoleBinding to allow Prometheus to list and watch OpenCost resources. |
+| opencost.platforms.openshift.enablePromAccess | bool | `false` | If true, enable internal prom access |
+| opencost.platforms.openshift.enableSCC | bool | `false` | If true, set Security Context Constraints on serviceaccount for read/write premissions |
+| opencost.platforms.openshift.enabled | bool | `false` | Enable OpenShift specific configurations |
+| opencost.platforms.openshift.monitoringServiceAccountName | string | `"prometheus-k8s"` | Name of the Prometheus serviceaccount to bind to the Resource Reader Role Binding. |
+| opencost.platforms.openshift.monitoringServiceAccountNamespace | string | `"openshift-monitoring"` | Namespace of the Prometheus serviceaccount to bind to the Resource Reader Role Binding. |
 | opencost.prometheus.amp.enabled | bool | `false` | Use Amazon Managed Service for Prometheus (AMP) |
 | opencost.prometheus.amp.workspaceId | string | `""` | Workspace ID for AMP |
 | opencost.prometheus.bearer_token | string | `""` | Prometheus Bearer token |
@@ -123,7 +147,9 @@ $ helm install opencost opencost/opencost
 | opencost.prometheus.internal.enabled | bool | `true` | Use in-cluster Prometheus |
 | opencost.prometheus.internal.namespaceName | string | `"prometheus-system"` | Namespace of in-cluster Prometheus |
 | opencost.prometheus.internal.port | int | `80` | Service port of in-cluster Prometheus |
+| opencost.prometheus.internal.scheme | string | `"http"` | Scheme to use for in-cluster Prometheus |
 | opencost.prometheus.internal.serviceName | string | `"prometheus-server"` | Service name of in-cluster Prometheus |
+| opencost.prometheus.kubeRBACProxy | bool | `false` | If true, opencost will use kube-rbac-proxy to authenticate with in cluster Prometheus for openshift |
 | opencost.prometheus.password | string | `""` | Prometheus Basic auth password |
 | opencost.prometheus.password_key | string | `"DB_BASIC_AUTH_PW"` | Key in the secret that references the password |
 | opencost.prometheus.secret_name | string | `nil` | Secret name that contains credentials for Prometheus |
@@ -133,16 +159,12 @@ $ helm install opencost opencost/opencost
 | opencost.prometheus.thanos.internal.enabled | bool | `true` |  |
 | opencost.prometheus.thanos.internal.namespaceName | string | `"opencost"` |  |
 | opencost.prometheus.thanos.internal.port | int | `10901` |  |
+| opencost.prometheus.thanos.internal.scheme | string | `"http"` |  |
 | opencost.prometheus.thanos.internal.serviceName | string | `"my-thanos-query"` |  |
 | opencost.prometheus.thanos.maxSourceResolution | string | `""` |  |
 | opencost.prometheus.thanos.queryOffset | string | `""` |  |
 | opencost.prometheus.username | string | `""` | Prometheus Basic auth username |
 | opencost.prometheus.username_key | string | `"DB_BASIC_AUTH_USERNAME"` | Key in the secret that references the username |
-| opencost.platforms.openshift.enabled | bool | `false` | Enable OpenShift specific configurations |
-| opencost.platforms.openshift.createMonitoringClusterRoleBinding | bool | `false` | Create a ClusterRoleBinding to grant the OpenCost ServiceAccount access to query Prometheus. (Only when using in-cluster prometheus) |
-| opencost.platforms.openshift.createMonitoringResourceReaderRoleBinding | bool | `false` | Create a Role and RoleBinding to allow Prometheus to list and watch OpenCost resources. (Only when using in-cluster prometheus) |
-| opencost.platforms.openshift.monitoringServiceAccountName | string | `prometheus-k8s` | Name of the Prometheus serviceaccount to bind to the Resource Reader Role Binding. (Only when using in-cluster prometheus) |
-| opencost.platforms.openshift.monitoringServiceAccountNamespace | string | `openshift-monitoring` | Namespace of the Prometheus serviceaccount to bind to the Resource Reader Role Binding.. (Only when using in-cluster prometheus) |
 | opencost.sigV4Proxy.extraEnv | string | `nil` |  |
 | opencost.sigV4Proxy.host | string | `"aps-workspaces.us-west-2.amazonaws.com"` |  |
 | opencost.sigV4Proxy.image | string | `"public.ecr.aws/aws-observability/aws-sigv4-proxy:latest"` |  |
@@ -178,13 +200,18 @@ $ helm install opencost opencost/opencost
 | opencost.ui.readinessProbe.initialDelaySeconds | int | `30` | Number of seconds before probe is initiated |
 | opencost.ui.readinessProbe.path | string | `"/healthz"` | Probe path |
 | opencost.ui.readinessProbe.periodSeconds | int | `10` | Probe frequency in seconds |
-| opencost.ui.resources.limits | object | `{"cpu":"999m","memory":"1Gi"}` | CPU/Memory resource limits |
+| opencost.ui.resources.limits | object | `{"memory":"1Gi"}` | CPU/Memory resource limits |
 | opencost.ui.resources.requests | object | `{"cpu":"10m","memory":"55Mi"}` | CPU/Memory resource requests |
+| opencost.ui.route.annotations | object | `{}` | Annotations for Ingress resource |
+| opencost.ui.route.enabled | bool | `false` | OpenShift route for OpenCost UI |
+| opencost.ui.route.host | string | `"example.local"` |  |
+| opencost.ui.route.path | string | `nil` |  |
+| opencost.ui.route.targetPort | string | `"http-ui"` | Redirect ingress to an extraPort defined on the service such as oauth-proxy |
+| opencost.ui.route.tls | list | `[]` | Ingress TLS configuration |
 | opencost.ui.securityContext | object | `{}` | The security options the container should be run with |
 | opencost.ui.uiPort | int | `9090` |  |
+| opencost.ui.useDefaultFqdn | bool | `false` |  |
 | opencost.ui.useIPv6 | bool | `true` |  |
-| opencost.ui.useDefaultFqdn | bool | false | To use `<service>.<namespace>.svc.cluster.local` or `<service>.<namespace>` |
-| opencost.ui.modelFqdn | string | `nil` | Set the model fqdn to use for the upstream |
 | plugins.configs | string | `nil` |  |
 | plugins.enabled | bool | `false` |  |
 | plugins.folder | string | `"/opt/opencost/plugin"` |  |
@@ -197,6 +224,7 @@ $ helm install opencost opencost/opencost
 | plugins.install.securityContext.runAsUser | int | `1000` |  |
 | plugins.install.securityContext.seccompProfile.type | string | `"RuntimeDefault"` |  |
 | podAnnotations | object | `{}` | Annotations to add to the OpenCost Pod |
+| podAutomountServiceAccountToken | bool | `true` | Enable automounting of service account token at the pod level |
 | podLabels | object | `{}` | Labels to add to the OpenCost Pod |
 | podSecurityContext | object | `{}` | Holds pod-level security attributes and common container settings |
 | priorityClassName | string | `nil` | Pod priority |
@@ -216,4 +244,4 @@ $ helm install opencost opencost/opencost
 | updateStrategy | object | `{"rollingUpdate":{"maxSurge":1,"maxUnavailable":1},"type":"RollingUpdate"}` | Strategy to be used for the Deployment |
 
 ----------------------------------------------
-Autogenerated from chart metadata using [helm-docs v1.13.1](https://github.com/norwoodj/helm-docs/releases/v1.13.1)
+Autogenerated from chart metadata using [helm-docs v1.14.2](https://github.com/norwoodj/helm-docs/releases/v1.14.2)

--- a/charts/opencost/templates/deployment.yaml
+++ b/charts/opencost/templates/deployment.yaml
@@ -37,6 +37,7 @@ spec:
       securityContext: {{- toYaml . | nindent 8 }}
       {{- end }}
       serviceAccountName: {{ template "opencost.serviceAccountName" . }}
+      automountServiceAccountToken: {{ .Values.podAutomountServiceAccountToken }}
       {{- with .Values.opencost.tolerations }}
       tolerations: {{- toYaml . | nindent 8 }}
       {{- end }}

--- a/charts/opencost/values.yaml
+++ b/charts/opencost/values.yaml
@@ -84,6 +84,8 @@ secretAnnotations: {}
 podLabels: {}
 # --  Pod priority
 priorityClassName: ~
+# --  Enable automounting of service account token at the pod level
+podAutomountServiceAccountToken: true
 
 # -- Holds pod-level security attributes and common container settings
 podSecurityContext: {}


### PR DESCRIPTION
It's best practice to disable automounting the service account tokens. In heavily audited environments there is often an admission controller preventing pods starting that have automountServiceAccountToken enabled and the same with service accounts. They require it to be explicitly set to false.

This change makes that behaviour configurable per SA and pod.