### PR TITLE
(doc) update readme to easily install unittest

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ See the [Chart Documentation](https://github.com/opencost/opencost-helm-chart/bl
 
 [Testing](https://github.com/helm-unittest/helm-unittest) your chart (optional)
 
-Presumes you've got Helm unittest installed: (i.e. `helm plugin install unittest`) and that your in the root directory of your cloned repo:
+Presumes you've got Helm unittest installed: (i.e. `helm plugin install https://github.com/helm-unittest/helm-unittest`) and that your in the root directory of your cloned repo:
 
 ```console
 helm unittest charts/opencost


### PR DESCRIPTION
Looks a good practice to install plugins and an easier one-liner to install unittest instead of visiting the unittest URL for more documentation. 