### PR TITLE
Add support for Pod Disruption Budget

### DIFF
--- a/charts/opencost/Chart.yaml
+++ b/charts/opencost/Chart.yaml
@@ -9,7 +9,7 @@ keywords:
   - finops
   - monitoring
   - opencost
-version: 2.1.6
+version: 2.1.7
 maintainers:
   - name: jessegoodier
   - name: toscott

--- a/charts/opencost/README.md
+++ b/charts/opencost/README.md
@@ -212,6 +212,9 @@ $ helm install opencost opencost/opencost
 | opencost.ui.uiPort | int | `9090` |  |
 | opencost.ui.useDefaultFqdn | bool | `false` |  |
 | opencost.ui.useIPv6 | bool | `true` |  |
+| pdb.enabled | bool | `false` |  |
+| pdb.minAvailable | int | `nil` | Minimum number of pods that must be available after the eviction |
+| pdb.maxUnavailable | int | `nil` | Maximum number of pods that can be unavailable after the eviction |
 | plugins.configs | string | `nil` |  |
 | plugins.enabled | bool | `false` |  |
 | plugins.folder | string | `"/opt/opencost/plugin"` |  |

--- a/charts/opencost/templates/pdb.yaml
+++ b/charts/opencost/templates/pdb.yaml
@@ -1,0 +1,17 @@
+{{- if .Values.pdb.enabled }}
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: {{ include "opencost.fullname" . }}
+  labels: {{- include "opencost.labels" . | nindent 4 }}
+spec:
+  {{- if .Values.pdb.minAvailable }}
+  minAvailable: {{ .Values.pdb.minAvailable }}
+  {{- end }}
+  {{- if .Values.pdb.maxUnavailable }}
+  maxUnavailable: {{ .Values.pdb.maxUnavailable }}
+  {{- end }}
+  selector:
+    matchLabels:
+      {{- include "opencost.selectorLabels" . | nindent 6 }}
+{{- end }}

--- a/charts/opencost/values.yaml
+++ b/charts/opencost/values.yaml
@@ -116,6 +116,14 @@ service:
 rbac:
   enabled: true
 
+# PodDisruptionBudget for high availability
+pdb:
+  enabled: false
+  # -- Minimum number of pods that must be available after the eviction
+  minAvailable: ~
+  # -- Maximum number of pods that can be unavailable after the eviction
+  maxUnavailable: ~
+
 opencost:
   # -- <SECRET_NAME> for the secret containing the Cloud Costs cloud-integration.json https://www.opencost.io/docs/configuration/#cloud-costs
   # -- kubectl create secret generic <SECRET_NAME> --from-file=cloud-integration.json -n opencost


### PR DESCRIPTION
This PR intends to allow users to make OpenCost highly available by configuring a Pod Disruption Budget (affinity and replicas already present).

Fix for issue: https://github.com/opencost/opencost-helm-chart/issues/286