### PR TITLE
add option to override the default container command

### DIFF
--- a/charts/opencost/Chart.yaml
+++ b/charts/opencost/Chart.yaml
@@ -9,7 +9,7 @@ keywords:
   - finops
   - monitoring
   - opencost
-version: 2.1.7
+version: 2.1.8
 maintainers:
   - name: jessegoodier
   - name: toscott

--- a/charts/opencost/templates/deployment.yaml
+++ b/charts/opencost/templates/deployment.yaml
@@ -68,6 +68,11 @@ spec:
         - name: {{ include "opencost.fullname" . }}
           image: {{ include "opencost.fullImageName" . }}
           imagePullPolicy: {{ .Values.opencost.exporter.image.pullPolicy }}
+          {{- with .Values.opencost.exporter.command }}
+          {{- if . }}
+          command: {{- toYaml . | nindent 12 }}
+          {{- end }}
+          {{- end }}
           args:
           {{- range .Values.opencost.exporter.extraArgs }}
           - --{{ . }}

--- a/charts/opencost/values.yaml
+++ b/charts/opencost/values.yaml
@@ -149,6 +149,8 @@ opencost:
       fullImageName: null
     # -- List of extra arguments for the command, e.g.: log-format=json
     extraArgs: []
+    # -- Optional command to override the default container command
+    command: []
     # -- Number of OpenCost replicas to run
     replicas: 1
     resources:


### PR DESCRIPTION
We can run opencost in two modes, in agent mode only metrics are emitted and in the default mode it provides all the cost attribution api's in addition to cost metrics. But the helm chart doesn't provide an option to run opencost in `agent` mode. This PR adds that option.