### PR TITLE
Add `insecureSkipVerify` to `prometheus.external` 

### DIFF
--- a/charts/opencost/Chart.yaml
+++ b/charts/opencost/Chart.yaml
@@ -9,7 +9,7 @@ keywords:
   - finops
   - monitoring
   - opencost
-version: 2.2.0
+version: 2.2.1
 maintainers:
   - name: jessegoodier
   - name: toscott

--- a/charts/opencost/README.md
+++ b/charts/opencost/README.md
@@ -143,8 +143,8 @@ $ helm install opencost opencost/opencost
 | opencost.prometheus.bearer_token_key | string | `"DB_BEARER_TOKEN"` |  |
 | opencost.prometheus.existingSecretName | string | `nil` | Existing secret name that contains credentials for Prometheus |
 | opencost.prometheus.external.enabled | bool | `false` | Use external Prometheus (eg. Grafana Cloud) |
-| opencost.prometheus.external.insecureSkipVerify | bool | `false` | Whether to disable SSL certificate verification |
 | opencost.prometheus.external.url | string | `"https://prometheus.example.com/prometheus"` | External Prometheus url |
+| opencost.prometheus.insecureSkipVerify | bool | `false` | Whether to disable SSL certificate verification |
 | opencost.prometheus.internal.enabled | bool | `true` | Use in-cluster Prometheus |
 | opencost.prometheus.internal.namespaceName | string | `"prometheus-system"` | Namespace of in-cluster Prometheus |
 | opencost.prometheus.internal.port | int | `80` | Service port of in-cluster Prometheus |

--- a/charts/opencost/templates/deployment.yaml
+++ b/charts/opencost/templates/deployment.yaml
@@ -165,7 +165,7 @@ spec:
             - name: PROMETHEUS_SERVER_ENDPOINT
               value: {{ include "opencost.prometheusServerEndpoint" . | quote }}
             - name: INSECURE_SKIP_VERIFY
-              value: {{ .Values.opencost.prometheus.external.insecureSkipVerify | quote }}
+              value: {{ .Values.opencost.prometheus.insecureSkipVerify | quote }}
             {{- if .Values.opencost.exporter.cloudProviderApiKey }}
             - name: CLOUD_PROVIDER_API_KEY
               valueFrom:

--- a/charts/opencost/values.yaml
+++ b/charts/opencost/values.yaml
@@ -394,13 +394,13 @@ opencost:
     bearer_token_key: DB_BEARER_TOKEN
     # -- If true, opencost will use kube-rbac-proxy to authenticate with in cluster Prometheus for openshift
     kubeRBACProxy: false
+     # -- Whether to disable SSL certificate verification
+    insecureSkipVerify: false
     external:
       # -- Use external Prometheus (eg. Grafana Cloud)
       enabled: false
       # -- External Prometheus url
       url: "https://prometheus.example.com/prometheus"
-      # -- Whether to disable SSL certificate verification
-      insecureSkipVerify: false
     internal:
       # -- Use in-cluster Prometheus
       enabled: true


### PR DESCRIPTION
Allows a user to set `insecureSkipVerify` in the Helm `values.yaml` which will set the corresponding [`INSECURE_SKIP_VERIFY` env var](https://github.com/opencost/opencost/blob/develop/modules/prometheus-source/pkg/env/promenv.go#L30).

This is to allow external Prometheus/Prometheus-compatible instances to be used in `prometheus.external` even with unrecognized SLL certs. In particular, it is to resolve the following error:

```
tls: failed to verify certificate: x509: certificate signed by unknown authority
```