### PR TITLE
Add uiPath configuration for OpenCost UI

### DIFF
--- a/charts/opencost/Chart.yaml
+++ b/charts/opencost/Chart.yaml
@@ -9,7 +9,7 @@ keywords:
   - finops
   - monitoring
   - opencost
-version: 2.2.6
+version: 2.2.7
 maintainers:
   - name: jessegoodier
   - name: toscott

--- a/charts/opencost/README.md
+++ b/charts/opencost/README.md
@@ -211,6 +211,7 @@ $ helm install opencost opencost/opencost
 | opencost.ui.route.tls | list | `[]` | Ingress TLS configuration |
 | opencost.ui.securityContext | object | `{}` | The security options the container should be run with |
 | opencost.ui.uiPort | int | `9090` |  |
+| opencost.ui.uiPath | string | `/` | Base path for serving the UI. Requires building a custom image using the build argument "ui_path". |
 | opencost.ui.useDefaultFqdn | bool | `false` |  |
 | opencost.ui.useIPv6 | bool | `true` |  |
 | pdb.enabled | bool | `false` |  |

--- a/charts/opencost/templates/configmap-frontend.yaml
+++ b/charts/opencost/templates/configmap-frontend.yaml
@@ -64,9 +64,8 @@ data:
         }
 
         add_header Cache-Control "max-age=300";
-        location / {
-            root /var/www;
-            index index.html index.htm;
+        location {{ .Values.opencost.ui.uiPath }} {
+            alias /var/www/;
             try_files $uri /index.html;
         }
 
@@ -80,7 +79,7 @@ data:
             access_log /dev/null;
             return 200 'OK';
         }
-        location /model/ {
+        location {{ .Values.opencost.ui.uiPath | trimSuffix "/" }}/model/ {
             proxy_connect_timeout       180;
             proxy_send_timeout          180;
             proxy_read_timeout          180;

--- a/charts/opencost/values.yaml
+++ b/charts/opencost/values.yaml
@@ -457,6 +457,9 @@ opencost:
     # used in the default.nginx.conf if you want to switch for using with Docker
     # apiServer: 0.0.0.0
     uiPort: 9090
+    # Base path for serving the UI.
+    # Requires building a custom image using the build argument "ui_path".
+    uiPath: /
     # Set to true to use IPv6
     useIPv6: true
     # Liveness probe configuration


### PR DESCRIPTION
This PR depends directly on opencost-ui PR  [#106](https://github.com/opencost/opencost-ui/pull/106).

It enables customizing the path used to serve the OpenCost web UI.

This change also addresses some previously reported issues:
- https://github.com/opencost/opencost-helm-chart/issues/238
- https://github.com/opencost/opencost-helm-chart/issues/148