### PR TITLE
Add configs to mount custom ca certs to opencost container

### DIFF
--- a/charts/opencost/Chart.yaml
+++ b/charts/opencost/Chart.yaml
@@ -4,16 +4,16 @@ name: opencost
 description: OpenCost and OpenCost UI
 type: application
 keywords:
-  - cloud-costs
-  - cost-optimization
-  - finops
-  - monitoring
-  - opencost
-version: 2.2.7
+- cloud-costs
+- cost-optimization
+- finops
+- monitoring
+- opencost
+version: 2.3.0
 maintainers:
-  - name: jessegoodier
-  - name: toscott
-  - name: mittal-ishaan
-  - name: brito-rafa
-    email: rafa@stormforge.io
+- name: jessegoodier
+- name: toscott
+- name: mittal-ishaan
+- name: brito-rafa
+  email: rafa@stormforge.io
 home: https://github.com/opencost/opencost-helm-chart

--- a/charts/opencost/README.md
+++ b/charts/opencost/README.md
@@ -215,6 +215,12 @@ $ helm install opencost opencost/opencost
 | opencost.ui.uiPath | string | `/` | Base path for serving the UI. Requires building a custom image using the build argument "ui_path". |
 | opencost.ui.useDefaultFqdn | bool | `false` |  |
 | opencost.ui.useIPv6 | bool | `true` |  |
+| opencost.updateCaTrust.enabled | bool | `false` | Enable update of CA trust(Mount custom CA certificates to the opencost container) |
+| opencost.updateCaTrust.securityContext | object | `{}` | Security context for the init container that mounts the custom CA certificates |
+| opencost.updateCaTrust.caCertsSecret | string | `"ca-certs-secret"` | Name of the Secret containing custom CA certificates to mount to the opencost container |
+| opencost.updateCaTrust.caCertsConfig | string | `"ca-certs-config"` | Name of the ConfigMap containing CA certificates to mount to the opencost container |
+| opencost.updateCaTrust.resources | object | `{}` | Resources for the init container |
+| opencost.updateCaTrust.caCertsMountPath | string | `"/etc/pki/ca-trust/source/anchors"` | Path where the custom CA certificates will be mounted in the opencost container |
 | pdb.enabled | bool | `false` |  |
 | pdb.minAvailable | int | `nil` | Minimum number of pods that must be available after the eviction |
 | pdb.maxUnavailable | int | `nil` | Maximum number of pods that can be unavailable after the eviction |

--- a/charts/opencost/README.md
+++ b/charts/opencost/README.md
@@ -220,7 +220,6 @@ $ helm install opencost opencost/opencost
 | opencost.updateCaTrust.caCertsSecret | string | `"ca-certs-secret"` | Name of the Secret containing custom CA certificates to mount to the opencost container |
 | opencost.updateCaTrust.caCertsConfig | string | `"ca-certs-config"` | Name of the ConfigMap containing CA certificates to mount to the opencost container |
 | opencost.updateCaTrust.resources | object | `{}` | Resources for the init container |
-| opencost.updateCaTrust.caCertsMountPath | string | `"/etc/pki/ca-trust/source/anchors"` | Path where the custom CA certificates will be mounted in the opencost container |
 | pdb.enabled | bool | `false` |  |
 | pdb.minAvailable | int | `nil` | Minimum number of pods that must be available after the eviction |
 | pdb.maxUnavailable | int | `nil` | Maximum number of pods that can be unavailable after the eviction |

--- a/charts/opencost/templates/_helpers.tpl
+++ b/charts/opencost/templates/_helpers.tpl
@@ -222,3 +222,12 @@ apiVersion: networking.k8s.io/v1beta1
 {{- $checksum | sha256sum -}}
 {{- end -}}
 
+{{- define "opencost.caCertsSecretConfig.check" }}
+  {{- if .Values.opencost.updateCaTrust.enabled }}
+    {{- if and .Values.opencost.updateCaTrust.caCertsSecret .Values.opencost.updateCaTrust.caCertsConfig }}
+      {{- fail "Both caCertsSecret and caCertsConfig are defined. Please specify only one." }}
+    {{- else if and (not .Values.opencost.updateCaTrust.caCertsSecret) (not .Values.opencost.updateCaTrust.caCertsConfig) }}
+      {{- fail "Neither caCertsSecret nor caCertsConfig is defined, but updateCaTrust is enabled. Please specify one." }}
+    {{- end }}
+  {{- end }}
+{{- end }}

--- a/charts/opencost/templates/deployment.yaml
+++ b/charts/opencost/templates/deployment.yaml
@@ -84,7 +84,7 @@ spec:
               update-ca-certificates;
           volumeMounts:
             - name: ca-certs-secret
-              mountPath: {{ .Values.opencost.updateCaTrust.caCertsMountPath | quote }}
+              mountPath: "/usr/local/share/ca-certificates"
             - name: ssl-path
               mountPath: "/etc/ssl/certs"
               readOnly: false
@@ -342,7 +342,7 @@ spec:
             {{- end }}
             {{- if .Values.opencost.updateCaTrust.enabled }}
             - name: ca-certs-secret
-              mountPath: {{ .Values.opencost.updateCaTrust.caCertsMountPath | quote }}
+              mountPath: "/usr/local/share/ca-certificates"
             - name: ssl-path
               mountPath: "/etc/ssl/certs"
               readOnly: false

--- a/charts/opencost/templates/deployment.yaml
+++ b/charts/opencost/templates/deployment.yaml
@@ -51,8 +51,8 @@ spec:
       {{- with.Values.opencost.topologySpreadConstraints }}
       topologySpreadConstraints: {{- toYaml . | nindent 8 }}
       {{- end }}
-      {{- if or (and .Values.plugins.enabled .Values.plugins.install.enabled ) .Values.opencost.updateCaTrust.enabled }}
       initContainers:
+        {{- if (and .Values.plugins.enabled .Values.plugins.install.enabled ) }}
         - name: plugin-installer
           image: {{ .Values.plugins.install.fullImageName }}
           command: ["sh", "/install/install_plugins.sh"]
@@ -64,6 +64,7 @@ spec:
               mountPath: /install
             - name: plugins-dir
               mountPath: {{ .Values.plugins.folder }}
+        {{- end }}
         {{- if .Values.opencost.updateCaTrust.enabled }}
         - name: update-ca-trust
           image: {{ include "opencost.fullImageName" . }}
@@ -79,16 +80,15 @@ spec:
             - 'sh'
             - '-c'
             - >
-              mkdir -p /etc/pki/ca-trust/extracted/{edk2,java,openssl,pem};
-              /usr/bin/update-ca-trust extract;
+              mkdir -p /etc/ssl/certs;
+              update-ca-certificates;
           volumeMounts:
             - name: ca-certs-secret
               mountPath: {{ .Values.opencost.updateCaTrust.caCertsMountPath | quote }}
             - name: ssl-path
-              mountPath: "/etc/pki/ca-trust/extracted"
+              mountPath: "/etc/ssl/certs"
               readOnly: false
           {{- end}}
-      {{- end }}
       containers:
         - name: {{ include "opencost.fullname" . }}
           image: {{ include "opencost.fullImageName" . }}
@@ -344,7 +344,7 @@ spec:
             - name: ca-certs-secret
               mountPath: {{ .Values.opencost.updateCaTrust.caCertsMountPath | quote }}
             - name: ssl-path
-              mountPath: "/etc/pki/ca-trust/extracted"
+              mountPath: "/etc/ssl/certs"
               readOnly: false
             {{- end }}
             {{- with .Values.opencost.exporter.extraVolumeMounts }}

--- a/charts/opencost/templates/deployment.yaml
+++ b/charts/opencost/templates/deployment.yaml
@@ -1,5 +1,6 @@
 {{- include  "isPrometheusConfigValid" . }}
 {{- include  "kubeRBACProxyBearerTokenCheck" . }}
+{{ include "opencost.caCertsSecretConfig.check" . }}
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -50,19 +51,43 @@ spec:
       {{- with.Values.opencost.topologySpreadConstraints }}
       topologySpreadConstraints: {{- toYaml . | nindent 8 }}
       {{- end }}
-      {{- if (and .Values.plugins.enabled .Values.plugins.install.enabled )}}
+      {{- if or (and .Values.plugins.enabled .Values.plugins.install.enabled ) .Values.opencost.updateCaTrust.enabled }}
       initContainers:
         - name: plugin-installer
           image: {{ .Values.plugins.install.fullImageName }}
           command: ["sh", "/install/install_plugins.sh"]
-      {{- with .Values.plugins.install.securityContext }}
+          {{- with .Values.plugins.install.securityContext }}
           securityContext: {{- toYaml . | nindent 12 }}
-      {{- end }}
+          {{- end }}
           volumeMounts:
             - name: install-script
               mountPath: /install
             - name: plugins-dir
               mountPath: {{ .Values.plugins.folder }}
+        {{- if .Values.opencost.updateCaTrust.enabled }}
+        - name: update-ca-trust
+          image: {{ include "opencost.fullImageName" . }}
+          imagePullPolicy: {{ .Values.opencost.exporter.image.pullPolicy }}
+          {{- with .Values.opencost.updateCaTrust.securityContext }}
+          securityContext: {{- toYaml . | nindent 12 }}
+          {{- end }}
+          {{- with .Values.opencost.updateCaTrust.resources }}
+          resources:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          command:
+            - 'sh'
+            - '-c'
+            - >
+              mkdir -p /etc/pki/ca-trust/extracted/{edk2,java,openssl,pem};
+              /usr/bin/update-ca-trust extract;
+          volumeMounts:
+            - name: ca-certs-secret
+              mountPath: {{ .Values.opencost.updateCaTrust.caCertsMountPath | quote }}
+            - name: ssl-path
+              mountPath: "/etc/pki/ca-trust/extracted"
+              readOnly: false
+          {{- end}}
       {{- end }}
       containers:
         - name: {{ include "opencost.fullname" . }}
@@ -281,7 +306,7 @@ spec:
             - name: {{ $key }}
               value: {{ $value | quote }}
             {{- end }}
-          {{- if or .Values.plugins.enabled .Values.opencost.exporter.persistence.enabled .Values.opencost.exporter.extraVolumeMounts .Values.opencost.customPricing.enabled .Values.opencost.cloudIntegrationSecret}}
+          {{- if or .Values.plugins.enabled .Values.opencost.exporter.persistence.enabled .Values.opencost.exporter.extraVolumeMounts .Values.opencost.customPricing.enabled .Values.opencost.cloudIntegrationSecret .Values.opencost.updateCaTrust.enabled}}
           volumeMounts:
             {{- if .Values.plugins.enabled }}
             - mountPath: /opt/opencost/plugin
@@ -314,6 +339,13 @@ spec:
             {{- if .Values.opencost.cloudIntegrationSecret }}
             - name: cloud-integration
               mountPath: /var/configs/cloud-integration
+            {{- end }}
+            {{- if .Values.opencost.updateCaTrust.enabled }}
+            - name: ca-certs-secret
+              mountPath: {{ .Values.opencost.updateCaTrust.caCertsMountPath | quote }}
+            - name: ssl-path
+              mountPath: "/etc/pki/ca-trust/extracted"
+              readOnly: false
             {{- end }}
             {{- with .Values.opencost.exporter.extraVolumeMounts }}
               {{- toYaml . | nindent 12 }}
@@ -412,7 +444,7 @@ spec:
           {{- toYaml . | nindent 12 }}
           {{- end }}
         {{- end }}
-      {{- if or .Values.plugins.enabled .Values.opencost.exporter.persistence.enabled .Values.extraVolumes .Values.opencost.customPricing.enabled .Values.opencost.cloudIntegrationSecret .Values.opencost.ui.enabled }}
+      {{- if or .Values.plugins.enabled .Values.opencost.exporter.persistence.enabled .Values.extraVolumes .Values.opencost.customPricing.enabled .Values.opencost.cloudIntegrationSecret .Values.opencost.ui.enabled .Values.opencost.updateCaTrust.enabled }}
       volumes:
         {{- if .Values.plugins.enabled  }}
         {{- if .Values.plugins.install.enabled}}
@@ -460,6 +492,19 @@ spec:
         - name: empty-var-www
           emptyDir: {}
         {{- end }}
+        {{- end }}
+        {{- if .Values.opencost.updateCaTrust.enabled }}
+        - name: ca-certs-secret
+          {{- if .Values.opencost.updateCaTrust.caCertsSecret }}
+          secret:
+            defaultMode: 420
+            secretName: {{ .Values.opencost.updateCaTrust.caCertsSecret }}
+          {{- else }}
+          configMap:
+            name: {{ .Values.opencost.updateCaTrust.caCertsConfig }}
+          {{- end }}
+        - name: ssl-path
+          emptyDir: {}
         {{- end }}
         {{- with .Values.extraVolumes }}
           {{- toYaml . | nindent 8 }}

--- a/charts/opencost/values.yaml
+++ b/charts/opencost/values.yaml
@@ -209,7 +209,6 @@ opencost:
     # Path of CSV file
     csv_path: ""
 
-
     prometheusDataSource:
       # Set the resolution in second that prometheus queries will be performed at
       queryResolutionSeconds: 300
@@ -269,10 +268,10 @@ opencost:
       # -- A list of host rules used to configure the Ingress
       # @default -- See [values.yaml](values.yaml)
       hosts:
-        - host: example.local
-          paths:
-            - path: /
-              pathType: Prefix
+      - host: example.local
+        paths:
+        - path: /
+          pathType: Prefix
       # -- Redirect ingress to an extraPort defined on the service such as oauth-proxy
       servicePort: http
       # servicePort: oauth-proxy
@@ -323,7 +322,6 @@ opencost:
     monthToDateInterval: 6
     # -- The max number of days that any single query will be made to construct Cloud Costs
     queryWindowDays: 7
-
 
   metrics:
     kubeStateMetrics:
@@ -394,7 +392,7 @@ opencost:
     bearer_token_key: DB_BEARER_TOKEN
     # -- If true, opencost will use kube-rbac-proxy to authenticate with in cluster Prometheus for openshift
     kubeRBACProxy: false
-     # -- Whether to disable SSL certificate verification
+    # -- Whether to disable SSL certificate verification
     insecureSkipVerify: false
     external:
       # -- Use external Prometheus (eg. Grafana Cloud)
@@ -416,7 +414,7 @@ opencost:
       scheme: http
     amp:
       # -- Use Amazon Managed Service for Prometheus (AMP)
-      enabled: false  # If true, opencost will be configured to remote_write and query from Amazon Managed Service for Prometheus.
+      enabled: false # If true, opencost will be configured to remote_write and query from Amazon Managed Service for Prometheus.
       # -- Workspace ID for AMP
       workspaceId: ""
     thanos:
@@ -520,9 +518,9 @@ opencost:
       # -- A list of host rules used to configure the Ingress
       # @default -- See [values.yaml](values.yaml)
       hosts:
-        - host: example.local
-          paths:
-            - /
+      - host: example.local
+        paths:
+        - /
       # -- Redirect ingress to an extraPort defined on the service such as oauth-proxy
       servicePort: http-ui
       # servicePort: oauth-proxy
@@ -601,6 +599,22 @@ opencost:
     #       containerPort: 8082
     #       protocol: TCP
     #   resources: {}
+
+  updateCaTrust:
+    enabled: false
+    ## Security context settings for the init container.
+    securityContext:
+      runAsUser: 0
+      runAsGroup: 0
+      runAsNonRoot: false
+      allowPrivilegeEscalation: false
+      readOnlyRootFilesystem: true
+      seccompProfile:
+        type: RuntimeDefault
+    caCertsSecret: ca-certs-secret # The name of the Secret containing custom CA certificates to mount to the opencost container.
+    # caCertsConfig: ca-certs-config  # The name of the ConfigMap containing the CA trust configuration.
+    resources: {}
+    caCertsMountPath: /etc/pki/ca-trust/source/anchors # The path where the custom CA certificates will be mounted in the init container
 
   platforms:
     openshift:

--- a/charts/opencost/values.yaml
+++ b/charts/opencost/values.yaml
@@ -614,7 +614,6 @@ opencost:
     caCertsSecret: ca-certs-secret # The name of the Secret containing custom CA certificates to mount to the opencost container.
     # caCertsConfig: ca-certs-config  # The name of the ConfigMap containing the CA trust configuration.
     resources: {}
-    caCertsMountPath: /usr/local/share/ca-certificates # The path where the custom CA certificates will be mounted in the init container
 
   platforms:
     openshift:

--- a/charts/opencost/values.yaml
+++ b/charts/opencost/values.yaml
@@ -614,7 +614,7 @@ opencost:
     caCertsSecret: ca-certs-secret # The name of the Secret containing custom CA certificates to mount to the opencost container.
     # caCertsConfig: ca-certs-config  # The name of the ConfigMap containing the CA trust configuration.
     resources: {}
-    caCertsMountPath: /etc/pki/ca-trust/source/anchors # The path where the custom CA certificates will be mounted in the init container
+    caCertsMountPath: /usr/local/share/ca-certificates # The path where the custom CA certificates will be mounted in the init container
 
   platforms:
     openshift:


### PR DESCRIPTION
Resolves: https://github.com/opencost/opencost-helm-chart/issues/302
Added Helm value configs to allow users to mount customer certs to opencost container.
Reference taken from: 
https://github.com/kubecost/kubecost/pull/3763
https://jfrog.com/help/r/artifactory-how-to-add-custom-ssl-certificates-to-an-artifactory-pod-using-helm-charts/artifactory-how-to-add-custom-ssl-certificates-to-an-artifactory-pod-using-helm-charts