### PR TITLE
Add chart installation notes

### DIFF
--- a/charts/opencost/Chart.yaml
+++ b/charts/opencost/Chart.yaml
@@ -9,7 +9,7 @@ keywords:
   - finops
   - monitoring
   - opencost
-version: 2.2.7
+version: 2.2.8
 maintainers:
   - name: jessegoodier
   - name: toscott

--- a/charts/opencost/templates/NOTES.txt
+++ b/charts/opencost/templates/NOTES.txt
@@ -1,0 +1,21 @@
+Thank you for installing the OpenCost Helm Chart!
+
+Your release is named: {{ .Release.Name }}
+
+To verify that OpenCost is running, execute the following commands:
+
+1. Check the status of the pods:
+   kubectl get pods -l app.kubernetes.io/instance={{ .Release.Name }} -n {{ .Release.Namespace }}
+
+2. Access the OpenCost UI:
+
+   If the service is only accessible within the cluster, you can use port-forwarding:
+   export SVC_NAME={{ include "opencost.fullname" . }}
+   kubectl port-forward svc/$SVC_NAME 9090 -n {{ .Release.Namespace }}
+
+   Alternatively, you can port-forward directly to the OpenCost pod:
+   export POD_NAME=$(kubectl get pod -l app.kubernetes.io/instance={{ .Release.Name }} -n {{ .Release.Namespace }} -o jsonpath="{.items[0].metadata.name}")
+   kubectl -n {{ .Release.Namespace }} port-forward $POD_NAME 9090
+
+For more information, visit the OpenCost documentation:
+https://www.opencost.io/docs/


### PR DESCRIPTION
Fix #304 

Adding installation notes for users concerning accessing the OpenCost UI

<img width="2646" height="1304" alt="Screenshot 2025-09-11 at 16 39 00" src="https://github.com/user-attachments/assets/51975640-f3e0-4730-baf8-74b76026a1ab" />
