### PR TITLE
feat: Add plugins.install.plugins list and existingSecret support

### DIFF
--- a/charts/opencost/templates/deployment.yaml
+++ b/charts/opencost/templates/deployment.yaml
@@ -335,7 +335,12 @@ spec:
             - mountPath: /opt/opencost/plugin
               name: plugins-dir
               readOnly: false
-            {{- range $key, $config := .Values.plugins.configs }}
+            {{- /* Mount plugin config files - use install.plugins list if set, otherwise fall back to configs keys */}}
+            {{- $pluginList := .Values.plugins.install.plugins }}
+            {{- if not $pluginList }}
+            {{- $pluginList = keys .Values.plugins.configs }}
+            {{- end }}
+            {{- range $key := $pluginList }}
             - mountPath: /opt/opencost/plugin/config/{{$key}}_config.json
               subPath: {{$key}}_config.json
               name: plugins-config
@@ -481,7 +486,8 @@ spec:
           emptyDir: {}
         - name: plugins-config
           secret:
-            secretName:  {{ template "opencost.fullname" . }}-plugins-config
+            {{- /* Use existingSecret if specified, otherwise use the generated secret name */}}
+            secretName: {{ .Values.plugins.existingSecret | default (printf "%s-plugins-config" (include "opencost.fullname" .)) }}
         {{- end }}
         {{- if .Values.opencost.customPricing.enabled }}
         - name: custom-configs

--- a/charts/opencost/templates/install-plugins.yaml
+++ b/charts/opencost/templates/install-plugins.yaml
@@ -38,7 +38,12 @@ data:
       VER=$(curl --silent https://api.github.com/repos/opencost/opencost-plugins/releases/latest | grep ".tag_name" | awk -F\" '{print $4}')
       {{- end }}
 
-      {{- range $pluginName, $config := .Values.plugins.configs }}
+      {{- /* Use plugins.install.plugins if specified, otherwise fall back to keys from plugins.configs */}}
+      {{- $pluginList := .Values.plugins.install.plugins }}
+      {{- if not $pluginList }}
+      {{- $pluginList = keys .Values.plugins.configs }}
+      {{- end }}
+      {{- range $pluginName := $pluginList }}
       curl -fsSLO "https://github.com/opencost/opencost-plugins/releases/download/$VER/{{ $pluginName }}.ocplugin.$OS.$ARCH"
       chmod a+rx "{{ $pluginName }}.ocplugin.$OS.$ARCH"
       {{- end }}

--- a/charts/opencost/templates/plugins-config.yaml
+++ b/charts/opencost/templates/plugins-config.yaml
@@ -1,4 +1,5 @@
-{{- if .Values.plugins.enabled }}
+{{- /* Only create the plugins-config secret if plugins are enabled and existingSecret is not specified */}}
+{{- if and .Values.plugins.enabled (not .Values.plugins.existingSecret) .Values.plugins.configs }}
 apiVersion: v1
 kind: Secret
 metadata:

--- a/charts/opencost/tests/plugins_test.yaml
+++ b/charts/opencost/tests/plugins_test.yaml
@@ -1,0 +1,89 @@
+suite: test plugins
+templates:
+  - templates/plugins-config.yaml
+  - templates/install-plugins.yaml
+tests:
+  # Test 1: Plugins disabled by default - no secret created
+  - it: should not create plugins-config secret when plugins disabled
+    template: templates/plugins-config.yaml
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  # Test 2: Old style - configs creates secret and downloads plugins
+  - it: should create plugins-config secret when using configs (legacy behavior)
+    template: templates/plugins-config.yaml
+    set:
+      plugins:
+        enabled: true
+        configs:
+          datadog: |
+            {"datadog_api_key": "test-key"}
+    asserts:
+      - isKind:
+          of: Secret
+      - matchRegex:
+          path: metadata.name
+          pattern: -plugins-config$
+      - exists:
+          path: data["datadog_config.json"]
+
+  # Test 3: New style - existingSecret should NOT create secret
+  - it: should not create plugins-config secret when existingSecret is set
+    template: templates/plugins-config.yaml
+    set:
+      plugins:
+        enabled: true
+        existingSecret: my-external-secret
+        install:
+          plugins:
+            - datadog
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  # Test 4: Install script uses plugins.install.plugins list when set
+  - it: should download plugins from install.plugins list
+    template: templates/install-plugins.yaml
+    set:
+      plugins:
+        enabled: true
+        install:
+          enabled: true
+          plugins:
+            - datadog
+            - mongodb
+    asserts:
+      - isKind:
+          of: ConfigMap
+      - matchRegex:
+          path: data["install_plugins.sh"]
+          pattern: datadog\.ocplugin
+      - matchRegex:
+          path: data["install_plugins.sh"]
+          pattern: mongodb\.ocplugin
+
+  # Test 5: Install script falls back to configs keys when install.plugins is empty
+  - it: should fall back to configs keys when install.plugins is empty
+    template: templates/install-plugins.yaml
+    set:
+      plugins:
+        enabled: true
+        install:
+          enabled: true
+        configs:
+          datadog: |
+            {"datadog_api_key": "test-key"}
+    asserts:
+      - isKind:
+          of: ConfigMap
+      - matchRegex:
+          path: data["install_plugins.sh"]
+          pattern: datadog\.ocplugin
+
+  # Test 6: No install script created when plugins disabled
+  - it: should not create install-plugins configmap when plugins disabled
+    template: templates/install-plugins.yaml
+    asserts:
+      - hasDocuments:
+          count: 0

--- a/charts/opencost/values.yaml
+++ b/charts/opencost/values.yaml
@@ -24,9 +24,19 @@ plugins:
       readOnlyRootFilesystem: true
       runAsNonRoot: true
       runAsUser: 1000
+    # -- List of plugins to download (decoupled from config).
+    # When specified, these plugins are downloaded regardless of what's in configs.
+    # This allows using existingSecret for credentials while still downloading plugin binaries.
+    # Example: ["datadog", "mongodb"]
+    # If empty, falls back to downloading plugins based on keys in configs (legacy behavior).
+    plugins: []
   folder: /opt/opencost/plugin
   # leave this commented to always download most recent version of plugins
   # version: <INSERT_SPECIFIC_PLUGINS_VERSION>
+  # -- Use an existing secret for plugin configuration instead of creating one from configs.
+  # The secret should contain files named <plugin>_config.json (e.g., datadog_config.json).
+  # This is useful when using ExternalSecrets or other secret management tools.
+  existingSecret: ""
   configs:
     # datadog: |
     #   {


### PR DESCRIPTION
## Summary

This PR decouples plugin binary downloads from plugin credentials, enabling secure secret management workflows (ExternalSecrets, Vault, etc.).

- Add `plugins.install.plugins` list to specify which plugins to download independently of configs
- Add `plugins.existingSecret` to use an existing secret instead of creating one from values
- Maintains full backward compatibility - existing configs-based workflows continue to work unchanged

## Problem

The current plugin installation mechanism requires plugin configurations to be defined in `plugins.configs` for the install script to download the plugin binary. This creates a security issue because:

1. The install script iterates over `plugins.configs` to determine which plugins to download
2. Plugin configs contain secrets (e.g., Datadog API key, App key)
3. Values files are often committed to git, exposing credentials

This makes it impossible to use Kubernetes ExternalSecrets, Vault, or other secret management tools for plugin credentials.

## Solution

### New Values

```yaml
plugins:
  enabled: true
  install:
    plugins:        # NEW: List of plugins to download (independent of configs)
      - datadog
  existingSecret: "my-datadog-plugin-secret"  # NEW: Use existing secret
  # configs not needed - credentials come from existingSecret
```

### Behavior

- If `plugins.install.plugins` is set, download those plugins regardless of what's in configs
- If `plugins.install.plugins` is empty, fall back to downloading plugins based on keys in configs (legacy behavior)
- If `plugins.existingSecret` is set, use that secret instead of creating one from configs
- If `plugins.existingSecret` is not set, create the secret from configs (legacy behavior)

## Test plan

- [x] `helm lint` passes
- [x] Unit tests added and passing (6 tests)
- [x] Template rendering verified for new style (existingSecret + install.plugins)
- [x] Template rendering verified for old style (configs only) - backward compatible

Fixes #327

🤖 Generated with [Claude Code](https://claude.ai/code)