### PR TITLE
feat: add OCI cloud cost configuration example to cloudIntegrationJSON

### DIFF
--- a/charts/opencost/Chart.yaml
+++ b/charts/opencost/Chart.yaml
@@ -9,7 +9,7 @@ keywords:
   - finops
   - monitoring
   - opencost
-version: 2.5.15
+version: 2.5.16
 maintainers:
   - name: jessegoodier
   - name: toscott

--- a/charts/opencost/values.yaml
+++ b/charts/opencost/values.yaml
@@ -200,7 +200,23 @@ opencost:
   #           "client_x509_cert_url": "my-x509-cert-url"
   #         }
   #       }
-  #     ]
+  #     ],
+  #     "oci": {
+  #       "usageApi": [
+  #         {
+  #           "tenancyID": "ocid1.tenancy.oc1..my-tenancy-ocid",
+  #           "region": "us-ashburn-1",
+  #           "authorizer": {
+  #             "authorizerType": "OCIRawConfigProvider",
+  #             "tenancyId": "ocid1.tenancy.oc1..my-tenancy-ocid",
+  #             "userId": "ocid1.user.oc1..my-user-ocid",
+  #             "region": "us-ashburn-1",
+  #             "fingerprint": "xx:xx:xx:xx:xx:xx:xx:xx:xx:xx:xx:xx:xx:xx:xx:xx",
+  #             "privateKey": "-----BEGIN RSA PRIVATE KEY-----\nmy-pem-encoded-private-key\n-----END RSA PRIVATE KEY-----"
+  #           }
+  #         }
+  #       ]
+  #     }
   #   }
 
   # -- MCP (Model Context Protocol) Server Configuration
@@ -476,6 +492,7 @@ opencost:
       zoneNetworkEgress: 0.01
       regionNetworkEgress: 0.01
       internetNetworkEgress: 0.12
+      # spotDataFeedEnabled: "false"  # Set to "false" to disable AWS spot data feed when not using spot instances
 
   retention1d: 15
   retention1h: 49

--- a/charts/opencost/values.yaml
+++ b/charts/opencost/values.yaml
@@ -162,6 +162,9 @@ opencost:
   # -- "<fullname>-cloud-integration" in the release namespace. Mutually exclusive with
   # -- opencost.cloudIntegrationSecret.
   cloudIntegrationJSON: ""
+  # For OCI, cloud-integration.json uses "oci" as an object with a "usageApi" array (not a
+  # top-level provider array like aws/azure/gcp). The authorizer uses "tenancyId" while the outer
+  # Usage API entry uses "tenancyID"; both spellings are required by OpenCost's schema.
   # cloudIntegrationJSON: |-
   #   {
   #     "aws": [
@@ -492,7 +495,6 @@ opencost:
       zoneNetworkEgress: 0.01
       regionNetworkEgress: 0.01
       internetNetworkEgress: 0.12
-      # spotDataFeedEnabled: "false"  # Set to "false" to disable AWS spot data feed when not using spot instances
 
   retention1d: 15
   retention1h: 49

--- a/charts/opencost/values.yaml
+++ b/charts/opencost/values.yaml
@@ -162,9 +162,6 @@ opencost:
   # -- "<fullname>-cloud-integration" in the release namespace. Mutually exclusive with
   # -- opencost.cloudIntegrationSecret.
   cloudIntegrationJSON: ""
-  # For OCI, cloud-integration.json uses "oci" as an object with a "usageApi" array (not a
-  # top-level provider array like aws/azure/gcp). The authorizer uses "tenancyId" while the outer
-  # Usage API entry uses "tenancyID"; both spellings are required by OpenCost's schema.
   # cloudIntegrationJSON: |-
   #   {
   #     "aws": [

--- a/charts/opencost/values.yaml
+++ b/charts/opencost/values.yaml
@@ -215,7 +215,7 @@ opencost:
   #             "userId": "ocid1.user.oc1..my-user-ocid",
   #             "region": "us-ashburn-1",
   #             "fingerprint": "xx:xx:xx:xx:xx:xx:xx:xx:xx:xx:xx:xx:xx:xx:xx:xx",
-  #             "privateKey": "-----BEGIN RSA PRIVATE KEY-----\nmy-pem-encoded-private-key\n-----END RSA PRIVATE KEY-----"
+  #             "privateKey": "REPLACE_WITH_YOUR_OCI_KEY_FILE_CONTENTS"
   #           }
   #         }
   #       ]

--- a/charts/opencost/values.yaml
+++ b/charts/opencost/values.yaml
@@ -208,8 +208,8 @@ opencost:
   #           "region": "us-ashburn-1",
   #           "authorizer": {
   #             "authorizerType": "OCIRawConfigProvider",
-  #             "tenancyId": "ocid1.tenancy.oc1..my-tenancy-ocid",
-  #             "userId": "ocid1.user.oc1..my-user-ocid",
+  #             "tenancyID": "ocid1.tenancy.oc1..my-tenancy-ocid",
+  #             "userID": "ocid1.user.oc1..my-user-ocid",
   #             "region": "us-ashburn-1",
   #             "fingerprint": "xx:xx:xx:xx:xx:xx:xx:xx:xx:xx:xx:xx:xx:xx:xx:xx",
   #             "privateKey": "REPLACE_WITH_YOUR_OCI_KEY_FILE_CONTENTS"


### PR DESCRIPTION
## Summary

This PR adds an OCI configuration example to the `cloudIntegrationJSON` section in `values.yaml`.

OCI Cloud Costs support already exists in OpenCost (see #3003), but the lack of documentation/examples makes it difficult for users to discover and configure.

## Changes
- Added OCI configuration example under `cloudIntegrationJSON`
- Matches structure of existing providers (AWS, Azure, GCP)

## Why this matters
Users rely on this section as a reference when configuring cloud integrations. Including OCI improves discoverability and usability.

## Testing
- Verified YAML structure
- No breaking changes

Closes #3003