### PR TITLE
feat(httproute): add optional kind and group fields to parentRefs

### DIFF
--- a/charts/opencost/Chart.yaml
+++ b/charts/opencost/Chart.yaml
@@ -9,7 +9,7 @@ keywords:
   - finops
   - monitoring
   - opencost
-version: 2.5.17
+version: 2.5.18
 maintainers:
   - name: jessegoodier
   - name: toscott

--- a/charts/opencost/templates/httproute.yaml
+++ b/charts/opencost/templates/httproute.yaml
@@ -15,6 +15,12 @@ spec:
   parentRefs:
     {{- range .Values.opencost.ui.httpRoute.parentRefs }}
     - name: {{ .name }}
+      {{- if .kind }}
+      kind: {{ .kind }}
+      {{- end }}
+      {{- if .group }}
+      group: {{ .group }}
+      {{- end }}
       {{- if .namespace }}
       namespace: {{ .namespace }}
       {{- end }}
@@ -59,6 +65,12 @@ spec:
   parentRefs:
     {{- range .Values.opencost.exporter.apiHttpRoute.parentRefs }}
     - name: {{ .name }}
+      {{- if .kind }}
+      kind: {{ .kind }}
+      {{- end }}
+      {{- if .group }}
+      group: {{ .group }}
+      {{- end }}
       {{- if .namespace }}
       namespace: {{ .namespace }}
       {{- end }}
@@ -103,6 +115,12 @@ spec:
   parentRefs:
     {{- range .Values.opencost.mcp.httpRoute.parentRefs }}
     - name: {{ .name }}
+      {{- if .kind }}
+      kind: {{ .kind }}
+      {{- end }}
+      {{- if .group }}
+      group: {{ .group }}
+      {{- end }}
       {{- if .namespace }}
       namespace: {{ .namespace }}
       {{- end }}

--- a/charts/opencost/templates/httproute.yaml
+++ b/charts/opencost/templates/httproute.yaml
@@ -15,12 +15,12 @@ spec:
   parentRefs:
     {{- range .Values.opencost.ui.httpRoute.parentRefs }}
     - name: {{ .name }}
-      {{- if .kind }}
-      kind: {{ .kind }}
-      {{- end }}
-      {{- if .group }}
-      group: {{ .group }}
-      {{- end }}
+      {{ if .kind }}
+      kind: {{ .kind | quote }}
+      {{ end }}
+      {{ if .group }}
+      group: {{ .group | quote }}
+      {{ end }}
       {{- if .namespace }}
       namespace: {{ .namespace }}
       {{- end }}

--- a/charts/opencost/templates/httproute.yaml
+++ b/charts/opencost/templates/httproute.yaml
@@ -65,12 +65,12 @@ spec:
   parentRefs:
     {{- range .Values.opencost.exporter.apiHttpRoute.parentRefs }}
     - name: {{ .name }}
-      {{- if .kind }}
-      kind: {{ .kind }}
-      {{- end }}
-      {{- if .group }}
-      group: {{ .group }}
-      {{- end }}
+      {{ if .kind }}
+      kind: {{ .kind | quote }}
+      {{ end }}
+      {{ if .group }}
+      group: {{ .group | quote }}
+      {{ end }}
       {{- if .namespace }}
       namespace: {{ .namespace }}
       {{- end }}
@@ -115,12 +115,12 @@ spec:
   parentRefs:
     {{- range .Values.opencost.mcp.httpRoute.parentRefs }}
     - name: {{ .name }}
-      {{- if .kind }}
-      kind: {{ .kind }}
-      {{- end }}
-      {{- if .group }}
-      group: {{ .group }}
-      {{- end }}
+      {{ if .kind }}
+      kind: {{ .kind | quote }}
+      {{ end }}
+      {{ if .group }}
+      group: {{ .group | quote }}
+      {{ end }}
       {{- if .namespace }}
       namespace: {{ .namespace }}
       {{- end }}

--- a/charts/opencost/values.yaml
+++ b/charts/opencost/values.yaml
@@ -256,6 +256,8 @@ opencost:
       # @default -- See [values.yaml](values.yaml)
       parentRefs:
         - name: ""
+          # kind: ""
+          # group: ""
           namespace: ""
           sectionName: ""
       # -- Hostnames for the HTTPRoute
@@ -450,6 +452,8 @@ opencost:
       # @default -- See [values.yaml](values.yaml)
       parentRefs:
         - name: ""
+          # kind: ""
+          # group: ""
           namespace: ""
           sectionName: ""
       # -- Hostnames for the HTTPRoute
@@ -751,6 +755,8 @@ opencost:
       # @default -- See [values.yaml](values.yaml)
       parentRefs:
         - name: ""
+          # kind: ""
+          # group: ""
           namespace: ""
           sectionName: ""
       # -- Hostnames for the HTTPRoute


### PR DESCRIPTION
Add `kind` and `group` to `HTTPRoute` `parentRefs`

Required to support `ListenerSet` as a parent resource for `HTTPRoute`, promoted to Standard channel in [Gateway API v1.5](https://kubernetes.io/blog/2026/04/21/gateway-api-v1-5/)
See https://gateway-api.sigs.k8s.io/guides/listener-set/

Changes
- Add optional `kind` and `group` fields in `httproute.yaml` (ui, api, mcp)
- Add them as commented fields in `values.yaml` (defaults to `kind: Gateway`)