### PR TITLE
Consistent Usage of `opencost.namespace` Helper

### DIFF
--- a/charts/opencost/Chart.yaml
+++ b/charts/opencost/Chart.yaml
@@ -9,7 +9,7 @@ keywords:
   - finops
   - monitoring
   - opencost
-version: 2.5.18
+version: 2.5.19
 maintainers:
   - name: jessegoodier
   - name: toscott

--- a/charts/opencost/templates/configmap-frontend.yaml
+++ b/charts/opencost/templates/configmap-frontend.yaml
@@ -4,7 +4,7 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: opencost-ui-nginx-config
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ include "opencost.namespace" . }}
 data:
   nginx.conf: |
     gzip_static  on;
@@ -43,11 +43,11 @@ data:
 
     upstream model {
     {{- if .Values.opencost.ui.useDefaultFqdn }}
-            server {{ $serviceName }}.{{ .Release.Namespace }}.svc.cluster.local:9003;
+            server {{ $serviceName }}.{{ include "opencost.namespace" . }}.svc.cluster.local:9003;
     {{- else if .Values.opencost.ui.modelFqdn }}
             server {{ .Values.opencost.ui.modelFqdn }};
     {{- else }}
-            server {{ $serviceName }}.{{ .Release.Namespace }}:9003;
+            server {{ $serviceName }}.{{ include "opencost.namespace" . }}:9003;
     {{- end }}
     }
 

--- a/charts/opencost/templates/install-plugins.yaml
+++ b/charts/opencost/templates/install-plugins.yaml
@@ -3,6 +3,7 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: {{ template "opencost.fullname" . }}-install-plugins
+  namespace: {{ include "opencost.namespace" . }}
   labels:
     app: {{ template "opencost.name" . }}
     chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}

--- a/charts/opencost/templates/pdb.yaml
+++ b/charts/opencost/templates/pdb.yaml
@@ -3,6 +3,7 @@ apiVersion: policy/v1
 kind: PodDisruptionBudget
 metadata:
   name: {{ include "opencost.fullname" . }}
+  namespace: {{ include "opencost.namespace" . }}
   labels: {{- include "opencost.labels" . | nindent 4 }}
 spec:
   {{- if .Values.pdb.minAvailable }}

--- a/charts/opencost/templates/plugins-config.yaml
+++ b/charts/opencost/templates/plugins-config.yaml
@@ -5,6 +5,7 @@ apiVersion: v1
 kind: Secret
 metadata:
   name: {{ include "opencost.pluginsConfigSecretName" . }}
+  namespace: {{ include "opencost.namespace" . }}
   labels:
     app: {{ template "opencost.name" . }}
     chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}


### PR DESCRIPTION
I added `metadata.namespace` to all namespaced resources using the helper function `opencost.namespace`. Also the helper is now used to generate `nginx.conf` for the frontend Deployment.