### PR TITLE
feat: add extraObjects for tpl-rendered extra manifests

### DIFF
--- a/charts/opencost/Chart.yaml
+++ b/charts/opencost/Chart.yaml
@@ -9,7 +9,7 @@ keywords:
   - finops
   - monitoring
   - opencost
-version: 2.5.18
+version: 2.5.19
 maintainers:
   - name: jessegoodier
   - name: toscott

--- a/charts/opencost/Chart.yaml
+++ b/charts/opencost/Chart.yaml
@@ -9,7 +9,7 @@ keywords:
   - finops
   - monitoring
   - opencost
-version: 2.5.20
+version: 2.5.21
 maintainers:
   - name: jessegoodier
   - name: toscott

--- a/charts/opencost/Chart.yaml
+++ b/charts/opencost/Chart.yaml
@@ -9,7 +9,7 @@ keywords:
   - finops
   - monitoring
   - opencost
-version: 2.5.19
+version: 2.5.20
 maintainers:
   - name: jessegoodier
   - name: toscott

--- a/charts/opencost/README.md
+++ b/charts/opencost/README.md
@@ -2,9 +2,9 @@
 
 OpenCost and OpenCost UI
 
-![Version: 2.5.0](https://img.shields.io/badge/Version-2.5.0-informational?style=flat-square)
+![Version: 2.5.18](https://img.shields.io/badge/Version-2.5.18-informational?style=flat-square)
 ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
-![AppVersion: 1.118.0](https://img.shields.io/badge/AppVersion-1.118.0-informational?style=flat-square)
+![AppVersion: 1.120.1](https://img.shields.io/badge/AppVersion-1.120.1-informational?style=flat-square)
 [![Artifact Hub](https://img.shields.io/endpoint?url=https://artifacthub.io/badge/repository/opencost)](https://artifacthub.io/packages/search?repo=opencost)
 [![Artifact Hub](https://img.shields.io/endpoint?url=https://artifacthub.io/badge/repository/opencost-oci)](https://artifacthub.io/packages/search?repo=opencost-oci)
 
@@ -50,14 +50,18 @@ $ helm install opencost opencost/opencost
 | opencost.cloudCost.queryWindowDays | int | `7` | The max number of days that any single query will be made to construct Cloud Costs |
 | opencost.cloudCost.refreshRateHours | int | `6` | Number of hours between each run of the Cloud Cost pipeline |
 | opencost.cloudCost.runWindowDays | int | `3` | Number of days into the past that a Cloud Cost standard run will query for |
-| opencost.cloudIntegrationSecret | string | `""` | Existing secret name containing `cloud-integration.json` for Cloud Costs. Mutually exclusive with `opencost.cloudIntegrationJSON`. |
-| opencost.cloudIntegrationJSON | string | `""` | Raw JSON string for `cloud-integration.json`. Creates `<fullname>-cloud-integration` in the release namespace. Mutually exclusive with `opencost.cloudIntegrationSecret`. |
+| opencost.cloudIntegrationJSON | string | `""` | opencost.cloudIntegrationSecret. |
+| opencost.cloudIntegrationSecret | string | `""` | Mutually exclusive with opencost.cloudIntegrationJSON. |
 | opencost.customPricing.configPath | string | `"/tmp/custom-config"` | Path for the pricing configuration. |
 | opencost.customPricing.configmapName | string | `"custom-pricing-model"` | Customize the configmap name used for custom pricing |
 | opencost.customPricing.costModel | object | `{"CPU":1.25,"GPU":0.95,"RAM":0.5,"description":"Modified pricing configuration.","internetNetworkEgress":0.12,"regionNetworkEgress":0.01,"spotCPU":0.006655,"spotRAM":0.000892,"storage":0.25,"zoneNetworkEgress":0.01}` | More information about these values here: https://www.opencost.io/docs/configuration/on-prem#custom-pricing-using-the-opencost-helm-chart |
 | opencost.customPricing.createConfigmap | bool | `true` | Configures the pricing model provided in the values file. |
 | opencost.customPricing.enabled | bool | `false` | Enables custom pricing configuration |
 | opencost.customPricing.provider | string | `"custom"` | Sets the provider type for the custom pricing file. |
+| opencost.exporter.adminToken.enabled | bool | `false` | When true, the chart creates the admin-token Secret (if value is set) or mounts existingSecret as ADMIN_TOKEN. When false, ADMIN_TOKEN is not set and no secret is deployed. |
+| opencost.exporter.adminToken.existingSecret | string | `""` | Use an existing Secret for the admin token (recommended). Secret must contain the key below. |
+| opencost.exporter.adminToken.secretKey | string | `"ADMIN_TOKEN"` | Key in the Secret that holds the admin token (used for both value-created and existing secrets). |
+| opencost.exporter.adminToken.value | string | `""` | If set, the chart creates a Secret with this value and sets ADMIN_TOKEN from it (not recommended for production; use existingSecret instead). |
 | opencost.exporter.apiHttpRoute | object | `{"annotations":{},"enabled":false,"hostnames":[],"labels":{},"parentRefs":[{"name":"","namespace":"","sectionName":""}],"rules":[{"backendRefs":[{"name":"","port":9003}],"matches":[{"path":{"type":"PathPrefix","value":"/"}}]}]}` | HTTPRoute for OpenCost API (Gateway API) |
 | opencost.exporter.apiHttpRoute.annotations | object | `{}` | Annotations for HTTPRoute resource |
 | opencost.exporter.apiHttpRoute.enabled | bool | `false` | Enable HTTPRoute resource |
@@ -87,17 +91,13 @@ $ helm install opencost opencost/opencost
 | opencost.exporter.env | list | `[]` | List of additional environment variables to set in the container |
 | opencost.exporter.extraArgs | list | `[]` | List of extra arguments for the command, e.g.: log-format=json |
 | opencost.exporter.extraEnv | object | `{}` | Any extra environment variables you would like to pass on to the pod |
-| opencost.exporter.adminToken.enabled | bool | `false` | When true, set ADMIN_TOKEN from value or existingSecret; when false, ADMIN_TOKEN is not set and no admin-token Secret is deployed. |
-| opencost.exporter.adminToken.value | string | `""` | If set, the chart creates a Secret with this value and sets ADMIN_TOKEN from it (use existingSecret in production). |
-| opencost.exporter.adminToken.existingSecret | string | `""` | Use an existing Secret for the admin token; must contain the key in adminToken.secretKey. |
-| opencost.exporter.adminToken.secretKey | string | `"ADMIN_TOKEN"` | Key in the Secret that holds the admin token (for write operations: POST /serviceKey, cloud config endpoints). |
 | opencost.exporter.extraVolumeMounts | list | `[]` | A list of volume mounts to be added to the pod |
-| opencost.exporter.image | object | `{"fullImageName":null,"pullPolicy":"IfNotPresent","registry":"ghcr.io","repository":"opencost/opencost","tag":"1.118.0@sha256:c1a08767fe3c3b2964a75885c145bae0cba32225c0b4c1e0382a77566aef93e9"}` | This overrides the above defaultClusterId. Ensure the ConfigMap exists and contains the required CLUSTER_ID key. clusterIdConfigmap: cluster-id-configmap |
+| opencost.exporter.image | object | `{"fullImageName":null,"pullPolicy":"IfNotPresent","registry":"ghcr.io","repository":"opencost/opencost","tag":"1.120.1@sha256:b0701f9b54e43c9abee98f5784792a5b469ca8951e87da32b161c1fa539ab0e1"}` | This overrides the above defaultClusterId. Ensure the ConfigMap exists and contains the required CLUSTER_ID key. clusterIdConfigmap: cluster-id-configmap |
 | opencost.exporter.image.fullImageName | string | `nil` | Override the full image name for development purposes |
 | opencost.exporter.image.pullPolicy | string | `"IfNotPresent"` | Exporter container image pull policy |
 | opencost.exporter.image.registry | string | `"ghcr.io"` | Exporter container image registry |
 | opencost.exporter.image.repository | string | `"opencost/opencost"` | Exporter container image name |
-| opencost.exporter.image.tag | string | `"1.118.0@sha256:c1a08767fe3c3b2964a75885c145bae0cba32225c0b4c1e0382a77566aef93e9"` | Exporter container image tag |
+| opencost.exporter.image.tag | string | `"1.120.1@sha256:b0701f9b54e43c9abee98f5784792a5b469ca8951e87da32b161c1fa539ab0e1"` | Exporter container image tag |
 | opencost.exporter.livenessProbe.enabled | bool | `true` | Whether probe is enabled |
 | opencost.exporter.livenessProbe.failureThreshold | int | `3` | Number of failures for probe to be considered failed |
 | opencost.exporter.livenessProbe.initialDelaySeconds | int | `10` | Number of seconds before probe is initiated |
@@ -235,6 +235,10 @@ $ helm install opencost opencost/opencost
 | opencost.ui.livenessProbe.initialDelaySeconds | int | `30` | Number of seconds before probe is initiated |
 | opencost.ui.livenessProbe.path | string | `"/healthz"` | Probe path |
 | opencost.ui.livenessProbe.periodSeconds | int | `10` | Probe frequency in seconds |
+| opencost.ui.nginx | object | `{"proxyConnectTimeout":180,"proxyReadTimeout":180,"proxySendTimeout":180}` | Nginx proxy timeout settings (in seconds) |
+| opencost.ui.nginx.proxyConnectTimeout | int | `180` | Timeout for establishing a connection with the proxied server |
+| opencost.ui.nginx.proxyReadTimeout | int | `180` | Timeout for reading a response from the proxied server |
+| opencost.ui.nginx.proxySendTimeout | int | `180` | Timeout for transmitting a request to the proxied server |
 | opencost.ui.readinessProbe.enabled | bool | `true` | Whether probe is enabled |
 | opencost.ui.readinessProbe.failureThreshold | int | `3` | Number of failures for probe to be considered failed |
 | opencost.ui.readinessProbe.initialDelaySeconds | int | `30` | Number of seconds before probe is initiated |
@@ -271,7 +275,7 @@ $ helm install opencost opencost/opencost
 | plugins.folder | string | `"/opt/opencost/plugin"` |  |
 | plugins.install.enabled | bool | `true` |  |
 | plugins.install.fullImageName | string | `"curlimages/curl:latest"` |  |
-| plugins.install.plugins | list | `[]` | List of plugins to download, independent of `plugins.configs`. When specified, these plugins are downloaded regardless of what's in configs, which enables using `plugins.existingSecret` for credentials while still downloading plugin binaries. This list also drives which `<plugin>_config.json` subPaths the Deployment mounts, so each listed plugin MUST have a matching config source -- either a `plugins.configs.<plugin>` entry (when `plugins.existingSecret` is empty) or a `<plugin>_config.json` key in the Secret referenced by `plugins.existingSecret`. Missing entries cause Pod startup failures because the mounted subPath will not exist. When `plugins.existingSecret` is empty, the chart validates this at template-render time and fails with an actionable error; the check is skipped when `plugins.existingSecret` is set because the contents of an externally-managed Secret cannot be introspected from Helm. Example: ["datadog", "mongodb"]. If empty, falls back to downloading plugins based on keys in configs (legacy behavior). |
+| plugins.install.plugins | list | `[]` | List of plugins to download, independent of `plugins.configs`. When specified, these plugins are downloaded regardless of what's in configs, which enables using `plugins.existingSecret` for credentials while still downloading plugin binaries. This list also drives which `<plugin>_config.json` subPaths the Deployment mounts, so each listed plugin MUST have a matching config source -- either a `plugins.configs.<plugin>` entry (when `plugins.existingSecret` is empty) or a `<plugin>_config.json` key in the Secret referenced by `plugins.existingSecret`. Missing entries cause Pod startup failures because the mounted subPath will not exist. When `plugins.existingSecret` is empty, the chart validates this at template-render time and fails with an actionable error; the check is skipped when `plugins.existingSecret` is set because the contents of an externally-managed Secret cannot be introspected from Helm. Example: ["datadog", "mongodb"] If empty, falls back to downloading plugins based on keys in configs (legacy behavior). |
 | plugins.install.securityContext.allowPrivilegeEscalation | bool | `false` |  |
 | plugins.install.securityContext.capabilities.drop[0] | string | `"ALL"` |  |
 | plugins.install.securityContext.readOnlyRootFilesystem | bool | `true` |  |

--- a/charts/opencost/README.md
+++ b/charts/opencost/README.md
@@ -2,9 +2,9 @@
 
 OpenCost and OpenCost UI
 
-![Version: 2.5.20](https://img.shields.io/badge/Version-2.5.20-informational?style=flat-square)
+![Version: 2.5.21](https://img.shields.io/badge/Version-2.5.21-informational?style=flat-square)
 ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
-![AppVersion: 1.120.1](https://img.shields.io/badge/AppVersion-1.120.1-informational?style=flat-square)
+![AppVersion: 1.120.2](https://img.shields.io/badge/AppVersion-1.120.2-informational?style=flat-square)
 [![Artifact Hub](https://img.shields.io/endpoint?url=https://artifacthub.io/badge/repository/opencost)](https://artifacthub.io/packages/search?repo=opencost)
 [![Artifact Hub](https://img.shields.io/endpoint?url=https://artifacthub.io/badge/repository/opencost-oci)](https://artifacthub.io/packages/search?repo=opencost-oci)
 
@@ -51,8 +51,8 @@ $ helm install opencost opencost/opencost
 | opencost.cloudCost.queryWindowDays | int | `7` | The max number of days that any single query will be made to construct Cloud Costs |
 | opencost.cloudCost.refreshRateHours | int | `6` | Number of hours between each run of the Cloud Cost pipeline |
 | opencost.cloudCost.runWindowDays | int | `3` | Number of days into the past that a Cloud Cost standard run will query for |
-| opencost.cloudIntegrationJSON | string | `""` | opencost.cloudIntegrationSecret. |
-| opencost.cloudIntegrationSecret | string | `""` | Mutually exclusive with opencost.cloudIntegrationJSON. |
+| opencost.cloudIntegrationJSON | string | `""` | Raw JSON for `cloud-integration.json`. Creates a Secret named `<fullname>-cloud-integration` in the release namespace. Mutually exclusive with `opencost.cloudIntegrationSecret`. |
+| opencost.cloudIntegrationSecret | string | `""` | Existing Secret containing `cloud-integration.json` for Cloud Costs. See https://www.opencost.io/docs/configuration/#cloud-costs. Create with: `kubectl create secret generic <SECRET_NAME> --from-file=cloud-integration.json -n opencost`. Mutually exclusive with `opencost.cloudIntegrationJSON`. |
 | opencost.customPricing.configPath | string | `"/tmp/custom-config"` | Path for the pricing configuration. |
 | opencost.customPricing.configmapName | string | `"custom-pricing-model"` | Customize the configmap name used for custom pricing |
 | opencost.customPricing.costModel | object | `{"CPU":1.25,"GPU":0.95,"RAM":0.5,"description":"Modified pricing configuration.","internetNetworkEgress":0.12,"regionNetworkEgress":0.01,"spotCPU":0.006655,"spotRAM":0.000892,"storage":0.25,"zoneNetworkEgress":0.01}` | More information about these values here: https://www.opencost.io/docs/configuration/on-prem#custom-pricing-using-the-opencost-helm-chart |
@@ -93,12 +93,12 @@ $ helm install opencost opencost/opencost
 | opencost.exporter.extraArgs | list | `[]` | List of extra arguments for the command, e.g.: log-format=json |
 | opencost.exporter.extraEnv | object | `{}` | Any extra environment variables you would like to pass on to the pod |
 | opencost.exporter.extraVolumeMounts | list | `[]` | A list of volume mounts to be added to the pod |
-| opencost.exporter.image | object | `{"fullImageName":null,"pullPolicy":"IfNotPresent","registry":"ghcr.io","repository":"opencost/opencost","tag":"1.120.1@sha256:b0701f9b54e43c9abee98f5784792a5b469ca8951e87da32b161c1fa539ab0e1"}` | This overrides the above defaultClusterId. Ensure the ConfigMap exists and contains the required CLUSTER_ID key. clusterIdConfigmap: cluster-id-configmap |
+| opencost.exporter.image | object | `{"fullImageName":null,"pullPolicy":"IfNotPresent","registry":"ghcr.io","repository":"opencost/opencost","tag":"1.120.2@sha256:5f37f689557dbb6737a9182b70625bba55bbba843a2caaba5a79746945a56cc6"}` | This overrides the above defaultClusterId. Ensure the ConfigMap exists and contains the required CLUSTER_ID key. clusterIdConfigmap: cluster-id-configmap |
 | opencost.exporter.image.fullImageName | string | `nil` | Override the full image name for development purposes |
 | opencost.exporter.image.pullPolicy | string | `"IfNotPresent"` | Exporter container image pull policy |
 | opencost.exporter.image.registry | string | `"ghcr.io"` | Exporter container image registry |
 | opencost.exporter.image.repository | string | `"opencost/opencost"` | Exporter container image name |
-| opencost.exporter.image.tag | string | `"1.120.1@sha256:b0701f9b54e43c9abee98f5784792a5b469ca8951e87da32b161c1fa539ab0e1"` | Exporter container image tag |
+| opencost.exporter.image.tag | string | `"1.120.2@sha256:5f37f689557dbb6737a9182b70625bba55bbba843a2caaba5a79746945a56cc6"` | Exporter container image tag |
 | opencost.exporter.livenessProbe.enabled | bool | `true` | Whether probe is enabled |
 | opencost.exporter.livenessProbe.failureThreshold | int | `3` | Number of failures for probe to be considered failed |
 | opencost.exporter.livenessProbe.initialDelaySeconds | int | `10` | Number of seconds before probe is initiated |
@@ -276,7 +276,7 @@ $ helm install opencost opencost/opencost
 | plugins.folder | string | `"/opt/opencost/plugin"` |  |
 | plugins.install.enabled | bool | `true` |  |
 | plugins.install.fullImageName | string | `"curlimages/curl:latest"` |  |
-| plugins.install.plugins | list | `[]` | List of plugins to download, independent of `plugins.configs`. When specified, these plugins are downloaded regardless of what's in configs, which enables using `plugins.existingSecret` for credentials while still downloading plugin binaries. This list also drives which `<plugin>_config.json` subPaths the Deployment mounts, so each listed plugin MUST have a matching config source -- either a `plugins.configs.<plugin>` entry (when `plugins.existingSecret` is empty) or a `<plugin>_config.json` key in the Secret referenced by `plugins.existingSecret`. Missing entries cause Pod startup failures because the mounted subPath will not exist. When `plugins.existingSecret` is empty, the chart validates this at template-render time and fails with an actionable error; the check is skipped when `plugins.existingSecret` is set because the contents of an externally-managed Secret cannot be introspected from Helm. Example: ["datadog", "mongodb"] If empty, falls back to downloading plugins based on keys in configs (legacy behavior). |
+| plugins.install.plugins | list | `[]` | List of plugins to download, independent of `plugins.configs`. When specified, these plugins are downloaded regardless of what's in configs, which enables using `plugins.existingSecret` for credentials while still downloading plugin binaries. This list also drives which `<plugin>_config.json` subPaths the Deployment mounts, so each listed plugin MUST have a matching config source -- either a `plugins.configs.<plugin>` entry (when `plugins.existingSecret` is empty) or a `<plugin>_config.json` key in the Secret referenced by `plugins.existingSecret`. Missing entries cause Pod startup failures because the mounted subPath will not exist. When `plugins.existingSecret` is empty, the chart validates this at template-render time and fails with an actionable error; the check is skipped when `plugins.existingSecret` is set because the contents of an externally-managed Secret cannot be introspected from Helm. Example: ["datadog", "mongodb"]. If empty, falls back to downloading plugins based on keys in configs (legacy behavior). |
 | plugins.install.securityContext.allowPrivilegeEscalation | bool | `false` |  |
 | plugins.install.securityContext.capabilities.drop[0] | string | `"ALL"` |  |
 | plugins.install.securityContext.readOnlyRootFilesystem | bool | `true` |  |

--- a/charts/opencost/README.md
+++ b/charts/opencost/README.md
@@ -2,7 +2,7 @@
 
 OpenCost and OpenCost UI
 
-![Version: 2.5.19](https://img.shields.io/badge/Version-2.5.19-informational?style=flat-square)
+![Version: 2.5.20](https://img.shields.io/badge/Version-2.5.20-informational?style=flat-square)
 ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
 ![AppVersion: 1.120.1](https://img.shields.io/badge/AppVersion-1.120.1-informational?style=flat-square)
 [![Artifact Hub](https://img.shields.io/endpoint?url=https://artifacthub.io/badge/repository/opencost)](https://artifacthub.io/packages/search?repo=opencost)

--- a/charts/opencost/README.md
+++ b/charts/opencost/README.md
@@ -2,7 +2,7 @@
 
 OpenCost and OpenCost UI
 
-![Version: 2.5.18](https://img.shields.io/badge/Version-2.5.18-informational?style=flat-square)
+![Version: 2.5.19](https://img.shields.io/badge/Version-2.5.19-informational?style=flat-square)
 ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
 ![AppVersion: 1.120.1](https://img.shields.io/badge/AppVersion-1.120.1-informational?style=flat-square)
 [![Artifact Hub](https://img.shields.io/endpoint?url=https://artifacthub.io/badge/repository/opencost)](https://artifacthub.io/packages/search?repo=opencost)
@@ -31,6 +31,7 @@ $ helm install opencost opencost/opencost
 |-----|------|---------|-------------|
 | annotations | object | `{}` | Annotations to add to the all the resources |
 | clusterName | string | `"cluster.local"` | Override the default name of cluster - Can be found in /etc/kubernetes/admin.conf: clusters -> cluster -> name |
+| extraObjects | list | `[]` | Array of extra K8s manifests rendered through `tpl` and owned by the release. |
 | extraVolumes | list | `[]` | A list of volumes to be added to the pod |
 | fullnameOverride | string | `""` | Overwrite all resources name created by the chart |
 | imagePullSecrets | list | `[]` | List of secret names to use for pulling the images |

--- a/charts/opencost/templates/extra-objects.yaml
+++ b/charts/opencost/templates/extra-objects.yaml
@@ -1,0 +1,4 @@
+{{- range .Values.extraObjects }}
+---
+{{ tpl (toYaml .) $ }}
+{{- end }}

--- a/charts/opencost/values.yaml
+++ b/charts/opencost/values.yaml
@@ -859,3 +859,10 @@ opencost:
       enablePromAccess: false
 # -- A list of volumes to be added to the pod
 extraVolumes: []
+
+# -- Array of extra K8s manifests rendered through `tpl` and owned by the release.
+extraObjects: []
+  # - apiVersion: external-secrets.io/v1beta1
+  #   kind: ExternalSecret
+  #   metadata:
+  #     name: {{ include "opencost.fullname" . }}-cloud-integration

--- a/charts/opencost/values.yaml
+++ b/charts/opencost/values.yaml
@@ -37,7 +37,7 @@ plugins:
     # template-render time and fails with an actionable error; the check is
     # skipped when `plugins.existingSecret` is set because the contents of an
     # externally-managed Secret cannot be introspected from Helm.
-    # Example: ["datadog", "mongodb"]
+    # Example: ["datadog", "mongodb"].
     # If empty, falls back to downloading plugins based on keys in configs (legacy behavior).
     plugins: []
   folder: /opt/opencost/plugin
@@ -154,13 +154,14 @@ pdb:
   maxUnavailable: ~
 
 opencost:
-  # -- <SECRET_NAME> for the secret containing the Cloud Costs cloud-integration.json https://www.opencost.io/docs/configuration/#cloud-costs
-  # -- kubectl create secret generic <SECRET_NAME> --from-file=cloud-integration.json -n opencost
-  # -- Mutually exclusive with opencost.cloudIntegrationJSON.
+  # -- Existing Secret containing `cloud-integration.json` for Cloud Costs. See
+  # https://www.opencost.io/docs/configuration/#cloud-costs.
+  # Create with: `kubectl create secret generic <SECRET_NAME> --from-file=cloud-integration.json -n opencost`.
+  # Mutually exclusive with `opencost.cloudIntegrationJSON`.
   cloudIntegrationSecret: ""
-  # -- Specify the cloud integration information in JSON form. This will create a Secret named
-  # -- "<fullname>-cloud-integration" in the release namespace. Mutually exclusive with
-  # -- opencost.cloudIntegrationSecret.
+  # -- Raw JSON for `cloud-integration.json`. Creates a Secret named
+  # `<fullname>-cloud-integration` in the release namespace.
+  # Mutually exclusive with `opencost.cloudIntegrationSecret`.
   cloudIntegrationJSON: ""
   # cloudIntegrationJSON: |-
   #   {
@@ -865,4 +866,4 @@ extraObjects: []
   # - apiVersion: external-secrets.io/v1beta1
   #   kind: ExternalSecret
   #   metadata:
-  #     name: {{ include "opencost.fullname" . }}-cloud-integration
+  #     name: '{{ include "opencost.fullname" . }}-cloud-integration'


### PR DESCRIPTION
## Summary

Add a new `extraObjects` values key that renders user-provided Kubernetes manifests through `tpl`, enabling injection of arbitrary resources (ExternalSecret, SealedSecret, supplementary NetworkPolicy/HTTPRoute, ConfigMap, etc.) without forking the chart.

This mirrors a well-established pattern across major community charts:

- [`argo-cd`](https://github.com/argoproj/argo-helm/blob/main/charts/argo-cd/values.yaml) — `extraObjects`
- [`argo-events`](https://github.com/argoproj/argo-helm/blob/main/charts/argo-events/values.yaml) — `extraObjects`
- [`argo-rollouts`](https://github.com/argoproj/argo-helm/tree/main/charts/argo-rollouts) — `extraObjects`
- [`external-secrets`](https://github.com/external-secrets/external-secrets/blob/main/deploy/charts/external-secrets/values.yaml) — `extraObjects`
- [`prometheus-postgres-exporter`](https://github.com/prometheus-community/helm-charts/blob/main/charts/prometheus-postgres-exporter/values.yaml) — `extraManifests`

## Changes

- Add `extraObjects: []` to `values.yaml` with an ExternalSecret example
- Add `templates/extra-objects.yaml` that iterates the list and renders each entry via `tpl` so values can reference `.Release`, `.Values`, and helper templates
- Regenerate `README.md` via helm-docs
- Bump chart version `2.5.18` → `2.5.19`

## Why this matters

Today, users who need to ship ExternalSecret/SealedSecret resources alongside OpenCost have to either fork the chart or manage a separate release. `extraObjects` is the standard escape hatch and adds <10 lines of templating.

Objects defined here become owned by the Helm release and are removed on `helm uninstall` — documented inline in `values.yaml`.

## Testing

- `helm template` with `--set-json='extraObjects=[{...}]'` correctly renders `{{ .Release.Name }}` interpolation
- `helm template` with empty `extraObjects: []` produces no extra resources