### PR TITLE
feat(opencost-parquet-exporter): support custom commonLabels

### DIFF
--- a/charts/opencost-parquet-exporter/Chart.yaml
+++ b/charts/opencost-parquet-exporter/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.2.0
+version: 0.3.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/opencost-parquet-exporter/README.md
+++ b/charts/opencost-parquet-exporter/README.md
@@ -10,6 +10,7 @@ OpenCost Parquet Exporter
 |-----|------|---------|-------------|
 | activeDeadlineSeconds | int | `3600` | Keep job running (from start time) for [activeDeadlineSeconds]   |
 | awsRolename | string | `"testrole"` | AWS IAM role to use when writing to the S3 Bucket.  |
+| commonLabels | object | `{}` | Additional labels applied to the CronJob, the Job template, and the Pod template. Consistent with the parent `opencost` chart's `commonLabels`. Chart-managed keys (`helm.sh/chart`, `app.kubernetes.io/name`, `app.kubernetes.io/instance`, `app.kubernetes.io/version`, `app.kubernetes.io/managed-by`) are reserved and silently dropped to keep the chart's identity labels stable. |
 | concurrencyPolicy | string | `"Forbid"` | Do not allow multiple runs |
 | dnsConfig | object | `{"options":[{"name":"single-request-reopen"},{"name":"ndots","value":"2"}]}` | Specific DNS parameters of the pod |
 | dnsConfig.options[0] | object | `{"name":"single-request-reopen"}` | Turning this option on [...] so that if two requests from the same port are not handled correctly it will close the socket and open a new one before sending the second request. See also "[single-request-reopen](https://man7.org/linux/man-pages/man5/resolv.conf.5.html)" |

--- a/charts/opencost-parquet-exporter/templates/_helpers.tpl
+++ b/charts/opencost-parquet-exporter/templates/_helpers.tpl
@@ -43,6 +43,14 @@ Create default image tag taken from the AppVersion.
 
 {{/*
 Common labels
+
+User-supplied `.Values.commonLabels` are appended at the end of the label set,
+but any keys that collide with the chart-managed identity labels
+(`helm.sh/chart`, `app.kubernetes.io/{name,instance,version,managed-by}`) are
+silently dropped. This avoids duplicate YAML keys, keeps the chart's identity
+labels stable, and preserves the chart's original label order so Helm diffs stay
+minimal. The outer `with` guards against `commonLabels` being null/unset (which
+would otherwise make `omit` fail with a type error).
 */}}
 {{- define "opencost-parquet-exporter.labels" -}}
 helm.sh/chart: {{ include "opencost-parquet-exporter.chart" . }}
@@ -51,6 +59,12 @@ helm.sh/chart: {{ include "opencost-parquet-exporter.chart" . }}
 app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
 {{- end }}
 app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- with .Values.commonLabels }}
+{{- $extra := omit . "helm.sh/chart" "app.kubernetes.io/name" "app.kubernetes.io/instance" "app.kubernetes.io/version" "app.kubernetes.io/managed-by" }}
+{{- with $extra }}
+{{ toYaml . }}
+{{- end }}
+{{- end }}
 {{- end }}
 
 {{/*

--- a/charts/opencost-parquet-exporter/templates/cronjob.yaml
+++ b/charts/opencost-parquet-exporter/templates/cronjob.yaml
@@ -15,6 +15,8 @@ spec:
   jobTemplate:
     metadata:
       name: {{ include "opencost-parquet-exporter.name" $ }}
+      labels:
+{{ include "opencost-parquet-exporter.labels" . | indent 8 }}
     spec:
       activeDeadlineSeconds: {{ .Values.activeDeadlineSeconds }}
       ttlSecondsAfterFinished: {{ .Values.ttlSecondsAfterFinished }}

--- a/charts/opencost-parquet-exporter/values.yaml
+++ b/charts/opencost-parquet-exporter/values.yaml
@@ -64,3 +64,9 @@ dnsConfig:
 dnsPolicy: ClusterFirst
 restartPolicy: Never
 terminationGracePeriodSeconds: 30
+
+# -- Additional labels applied to the CronJob, the Job template, and the Pod template. Chart-managed keys
+# (`helm.sh/chart`, `app.kubernetes.io/name`, `app.kubernetes.io/instance`,
+# `app.kubernetes.io/version`, `app.kubernetes.io/managed-by`) are reserved and
+# silently dropped to keep the chart's identity labels stable.
+commonLabels: {}


### PR DESCRIPTION
## What this PR does

Adds a `commonLabels` value to the `opencost-parquet-exporter` subchart, allowing
users to attach additional custom labels to the chart's resources.

The labels are merged into the common labels helper and therefore applied to the
**CronJob**, the **Job template** and the **Pod template**. They are intentionally
kept out of `selectorLabels`, so the immutable pod selector is not affected.

## Why

Previously there was no way to add organization-specific labels (e.g. team,
cost-center, environment) to the parquet-exporter resources without patching the
templates. This is needed for label-based cost allocation, ownership and policy
enforcement.

The value is named `commonLabels` to stay consistent with the parent `opencost`
chart, which already exposes a `commonLabels` value for the same purpose.

## Changes

- `templates/_helpers.tpl`: merge `.Values.commonLabels` into the common labels helper
- `values.yaml`: add `commonLabels: {}` with documentation comment
- `README.md`: document the new value
- `Chart.yaml`: bump chart version `0.2.0` → `0.3.0`

## Usage

```yaml
# values.yaml
commonLabels:
  team: foo
  cost-center: bar