### PR TITLE
add timeout configuration for override in probes

### DIFF
--- a/charts/opencost/Chart.yaml
+++ b/charts/opencost/Chart.yaml
@@ -9,7 +9,7 @@ keywords:
   - finops
   - monitoring
   - opencost
-version: 2.5.25
+version: 2.5.26
 maintainers:
   - name: jessegoodier
   - name: toscott

--- a/charts/opencost/templates/deployment.yaml
+++ b/charts/opencost/templates/deployment.yaml
@@ -132,7 +132,7 @@ spec:
             periodSeconds: {{ .Values.opencost.exporter.livenessProbe.periodSeconds }}
             failureThreshold: {{ .Values.opencost.exporter.livenessProbe.failureThreshold }}
             timeoutSeconds: {{ .Values.opencost.exporter.livenessProbe.timeoutSeconds }}
-           {{- end }}
+          {{- end }}
           {{- if .Values.opencost.exporter.readinessProbe.enabled }}
           readinessProbe:
             httpGet:

--- a/charts/opencost/templates/deployment.yaml
+++ b/charts/opencost/templates/deployment.yaml
@@ -122,7 +122,6 @@ spec:
             periodSeconds: {{ .Values.opencost.exporter.startupProbe.periodSeconds }}
             failureThreshold: {{ .Values.opencost.exporter.startupProbe.failureThreshold }}
             timeoutSeconds: {{ .Values.opencost.exporter.startupProbe.timeoutSeconds }}
-            successThreshold: {{ .Values.opencost.exporter.startupProbe.successThreshold }}
           {{- end }}
           {{- if .Values.opencost.exporter.livenessProbe.enabled }}
           livenessProbe:
@@ -133,8 +132,7 @@ spec:
             periodSeconds: {{ .Values.opencost.exporter.livenessProbe.periodSeconds }}
             failureThreshold: {{ .Values.opencost.exporter.livenessProbe.failureThreshold }}
             timeoutSeconds: {{ .Values.opencost.exporter.livenessProbe.timeoutSeconds }}
-            successThreshold: {{ .Values.opencost.exporter.livenessProbe.successThreshold }}
-          {{- end }}
+           {{- end }}
           {{- if .Values.opencost.exporter.readinessProbe.enabled }}
           readinessProbe:
             httpGet:

--- a/charts/opencost/templates/deployment.yaml
+++ b/charts/opencost/templates/deployment.yaml
@@ -121,6 +121,8 @@ spec:
             initialDelaySeconds: {{ .Values.opencost.exporter.startupProbe.initialDelaySeconds }}
             periodSeconds: {{ .Values.opencost.exporter.startupProbe.periodSeconds }}
             failureThreshold: {{ .Values.opencost.exporter.startupProbe.failureThreshold }}
+            timeoutSeconds: {{ .Values.opencost.exporter.startupProbe.timeoutSeconds }}
+            successThreshold: {{ .Values.opencost.exporter.startupProbe.successThreshold }}
           {{- end }}
           {{- if .Values.opencost.exporter.livenessProbe.enabled }}
           livenessProbe:
@@ -130,6 +132,8 @@ spec:
             initialDelaySeconds: {{ .Values.opencost.exporter.livenessProbe.initialDelaySeconds }}
             periodSeconds: {{ .Values.opencost.exporter.livenessProbe.periodSeconds }}
             failureThreshold: {{ .Values.opencost.exporter.livenessProbe.failureThreshold }}
+            timeoutSeconds: {{ .Values.opencost.exporter.livenessProbe.timeoutSeconds }}
+            successThreshold: {{ .Values.opencost.exporter.livenessProbe.successThreshold }}
           {{- end }}
           {{- if .Values.opencost.exporter.readinessProbe.enabled }}
           readinessProbe:
@@ -139,6 +143,8 @@ spec:
             initialDelaySeconds: {{ .Values.opencost.exporter.readinessProbe.initialDelaySeconds }}
             periodSeconds: {{ .Values.opencost.exporter.readinessProbe.periodSeconds }}
             failureThreshold: {{ .Values.opencost.exporter.readinessProbe.failureThreshold }}
+            timeoutSeconds: {{ .Values.opencost.exporter.readinessProbe.timeoutSeconds }}
+            successThreshold: {{ .Values.opencost.exporter.readinessProbe.successThreshold }}
           {{- end }}
           {{- with .Values.opencost.exporter.securityContext }}
           securityContext: {{- toYaml . | nindent 12 }}

--- a/charts/opencost/tests/deployment_test.yaml
+++ b/charts/opencost/tests/deployment_test.yaml
@@ -14,17 +14,15 @@ tests:
       - matchRegex:
           path: spec.template.spec.containers[0].image
           pattern: ghcr\.io\/opencost\/opencost:[0-9]*\.[0-9]*\.[0-9]*
-  - it: should render custom probe timeout and success threshold values
+  - it: should render custom probe timeout values and readiness successThreshold
     set:
       image.tag: latest
       opencost:
         exporter:
           startupProbe:
             timeoutSeconds: 7
-            successThreshold: 2
           livenessProbe:
             timeoutSeconds: 8
-            successThreshold: 3
           readinessProbe:
             timeoutSeconds: 9
             successThreshold: 4

--- a/charts/opencost/tests/deployment_test.yaml
+++ b/charts/opencost/tests/deployment_test.yaml
@@ -33,14 +33,8 @@ tests:
           path: spec.template.spec.containers[0].startupProbe.timeoutSeconds
           value: 7
       - equal:
-          path: spec.template.spec.containers[0].startupProbe.successThreshold
-          value: 2
-      - equal:
           path: spec.template.spec.containers[0].livenessProbe.timeoutSeconds
           value: 8
-      - equal:
-          path: spec.template.spec.containers[0].livenessProbe.successThreshold
-          value: 3
       - equal:
           path: spec.template.spec.containers[0].readinessProbe.timeoutSeconds
           value: 9

--- a/charts/opencost/tests/deployment_test.yaml
+++ b/charts/opencost/tests/deployment_test.yaml
@@ -14,3 +14,36 @@ tests:
       - matchRegex:
           path: spec.template.spec.containers[0].image
           pattern: ghcr\.io\/opencost\/opencost:[0-9]*\.[0-9]*\.[0-9]*
+  - it: should render custom probe timeout and success threshold values
+    set:
+      image.tag: latest
+      opencost:
+        exporter:
+          startupProbe:
+            timeoutSeconds: 7
+            successThreshold: 2
+          livenessProbe:
+            timeoutSeconds: 8
+            successThreshold: 3
+          readinessProbe:
+            timeoutSeconds: 9
+            successThreshold: 4
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].startupProbe.timeoutSeconds
+          value: 7
+      - equal:
+          path: spec.template.spec.containers[0].startupProbe.successThreshold
+          value: 2
+      - equal:
+          path: spec.template.spec.containers[0].livenessProbe.timeoutSeconds
+          value: 8
+      - equal:
+          path: spec.template.spec.containers[0].livenessProbe.successThreshold
+          value: 3
+      - equal:
+          path: spec.template.spec.containers[0].readinessProbe.timeoutSeconds
+          value: 9
+      - equal:
+          path: spec.template.spec.containers[0].readinessProbe.successThreshold
+          value: 4

--- a/charts/opencost/values.yaml
+++ b/charts/opencost/values.yaml
@@ -340,7 +340,7 @@ opencost:
       # -- Number of failures for probe to be considered failed
       failureThreshold: 30
       # -- Number of seconds after which the probe times out
-      timeoutSeconds: 5
+      timeoutSeconds: 1
     # Liveness probe configuration
     livenessProbe:
       # -- Whether probe is enabled

--- a/charts/opencost/values.yaml
+++ b/charts/opencost/values.yaml
@@ -339,6 +339,10 @@ opencost:
       periodSeconds: 5
       # -- Number of failures for probe to be considered failed
       failureThreshold: 30
+      # -- Number of seconds after which the probe times out
+      timeoutSeconds: 5
+      # -- Minimum consecutive successes for the probe to be considered successful after having failed
+      successThreshold: 1
     # Liveness probe configuration
     livenessProbe:
       # -- Whether probe is enabled
@@ -351,6 +355,10 @@ opencost:
       periodSeconds: 20
       # -- Number of failures for probe to be considered failed
       failureThreshold: 3
+      # -- Number of seconds after which the probe times out
+      timeoutSeconds: 5
+      # -- Minimum consecutive successes for the probe to be considered successful after having failed
+      successThreshold: 1
     # Readiness probe configuration
     readinessProbe:
       # -- Whether probe is enabled
@@ -363,6 +371,10 @@ opencost:
       periodSeconds: 10
       # -- Number of failures for probe to be considered failed
       failureThreshold: 3
+      # -- Number of seconds after which the probe times out
+      timeoutSeconds: 5
+      # -- Minimum consecutive successes for the probe to be considered successful after having failed
+      successThreshold: 1
     # -- The security options the container should be run with
     securityContext: {}
       # capabilities:

--- a/charts/opencost/values.yaml
+++ b/charts/opencost/values.yaml
@@ -341,8 +341,6 @@ opencost:
       failureThreshold: 30
       # -- Number of seconds after which the probe times out
       timeoutSeconds: 5
-      # -- Minimum consecutive successes for the probe to be considered successful after having failed
-      successThreshold: 1
     # Liveness probe configuration
     livenessProbe:
       # -- Whether probe is enabled
@@ -357,8 +355,6 @@ opencost:
       failureThreshold: 3
       # -- Number of seconds after which the probe times out
       timeoutSeconds: 5
-      # -- Minimum consecutive successes for the probe to be considered successful after having failed
-      successThreshold: 1
     # Readiness probe configuration
     readinessProbe:
       # -- Whether probe is enabled

--- a/charts/opencost/values.yaml
+++ b/charts/opencost/values.yaml
@@ -354,7 +354,7 @@ opencost:
       # -- Number of failures for probe to be considered failed
       failureThreshold: 3
       # -- Number of seconds after which the probe times out
-      timeoutSeconds: 5
+      timeoutSeconds: 1
     # Readiness probe configuration
     readinessProbe:
       # -- Whether probe is enabled
@@ -368,7 +368,7 @@ opencost:
       # -- Number of failures for probe to be considered failed
       failureThreshold: 3
       # -- Number of seconds after which the probe times out
-      timeoutSeconds: 5
+      timeoutSeconds: 1
       # -- Minimum consecutive successes for the probe to be considered successful after having failed
       successThreshold: 1
     # -- The security options the container should be run with


### PR DESCRIPTION
These values are just explicit chart defaults. They preserve the current behavior because the defaults match the existing effective probe settings, while still allowing users to override them if needed.
issue - 

issue #367 