### PR TITLE
KCM-5392: Add support for configuring external labels for Opencost installation with Collector data source

### DIFF
--- a/charts/opencost/Chart.yaml
+++ b/charts/opencost/Chart.yaml
@@ -9,7 +9,7 @@ keywords:
   - finops
   - monitoring
   - opencost
-version: 2.5.26
+version: 2.5.27
 maintainers:
   - name: jessegoodier
   - name: toscott

--- a/charts/opencost/templates/deployment.yaml
+++ b/charts/opencost/templates/deployment.yaml
@@ -283,6 +283,24 @@ spec:
             {{- with .Values.opencost.exporter.env }}
               {{- toYaml . | nindent 12 }}
             {{- end }}
+            {{- $external := .Values.external | default dict }}
+            {{- $nodeLabels := $external.nodeLabels | default dict }}
+            {{- if $nodeLabels.configMapName }}
+            - name: EXTERNAL_NODELABELS_CONFIG_MAP_NAME
+              value: {{ $nodeLabels.configMapName | quote }}
+            {{- if $nodeLabels.namespace }}
+            - name: EXTERNAL_NODELABELS_NAMESPACE
+              value: {{ $nodeLabels.namespace | quote }}
+            {{- end }}
+            {{- if $nodeLabels.key }}
+            - name: EXTERNAL_NODELABELS_KEY
+              value: {{ $nodeLabels.key | quote }}
+            {{- end }}
+            {{- if $nodeLabels.route }}
+            - name: EXTERNAL_NODELABELS_ROUTE
+              value: {{ $nodeLabels.route | quote }}
+            {{- end }}
+            {{- end }}
             {{- if .Values.opencost.customPricing.enabled }}
             - name: CONFIG_PATH
               value: {{ .Values.opencost.customPricing.configPath | quote }}

--- a/charts/opencost/values.yaml
+++ b/charts/opencost/values.yaml
@@ -917,3 +917,67 @@ extraObjects: []
   #   kind: ExternalSecret
   #   metadata:
   #     name: '{{ include "opencost.fullname" . }}-cloud-integration'
+
+# External labels allow users to apply custom labels to node assets and
+# allocations.
+#
+# The OpenCost deployment can read external labels from an existing ConfigMap.
+#
+# Supported ConfigMap formats:
+#
+# 1. Traditional ConfigMap
+#
+#    data:
+#      cluster: prod
+#      env: dev
+#      region: nam
+#
+#    In this case, labels are read directly from ConfigMap.data. The
+#    key and route fields are optional and may be omitted.
+#
+# 2. Block-scalar ConfigMap
+#
+#    data:
+#      config.yaml: |
+#        metadata:
+#          externalLabels:
+#            cluster: prod
+#            env: dev
+#            region: nam
+#
+#    In this case, specify the key that contains the YAML document and
+#    a dot-separated route to the labels map within it.
+#
+# Fields:
+#   configMapName - name of the ConfigMap to read.
+#   namespace     - namespace of the ConfigMap. Defaults to the agent's
+#                   own namespace if left empty.
+#   key           - Optional. The ConfigMap data key containing the YAML
+#                   document. Required only for block-scalar ConfigMaps.
+#   route         - Optional. Dot-separated path to the labels map within
+#                   the key's YAML content, e.g. "metadata.externalLabels".
+#                   When omitted or empty, labels are read directly from
+#                   ConfigMap.data (traditional ConfigMap).
+#
+# Traditional ConfigMap example:
+#
+# external:
+#   nodeLabels:
+#     configMapName: external-label-configmap
+#     namespace: ""
+#
+# Block-scalar ConfigMap example:
+#
+# external:
+#   nodeLabels:
+#     configMapName: external-label-configmap
+#     namespace: ""
+#     key: config.yaml
+#     route: metadata.externalLabels
+external:
+  nodeLabels:
+    configMapName: ""
+    namespace: ""
+    key: ""
+    route: ""
+    

--- a/charts/opencost/values.yaml
+++ b/charts/opencost/values.yaml
@@ -980,4 +980,3 @@ external:
     namespace: ""
     key: ""
     route: ""
-    


### PR DESCRIPTION
Allows users to provide external node labels from a ConfigMap in any namespace within their cluster.

HOW WAS THIS TESTED
----------------------

Installed opencost with values

```
opencost:
  exporter:
    image:
      fullImageName: gcr.io/guestbook-227502/opencost:standalone_external_labels_0.02
    collectorDataSource:
      enabled: true  
external:
    nodeLabels:
      configMapName: "external-labels"
      namespace: "alan-external-config-test"
      key: "config.yaml"
      route: ""
```

Opencost log had a message watching the config in another namespace. 

```
2026-07-16T23:42:04.775475276Z INF Found configmap external-labels, watching...
2026-07-16T23:42:04.780732346Z INF Found configmap pricing-configs, watching...

```

Configmap out is:

```
(eks-f1b03ce5-c11y-matrix-233db8e4/alan-external-config-test) alanrodrigues@Alans-MacBook-Pro in /Users/alanrodrigues
>k get cm external-labels -oyaml
apiVersion: v1
data:
  config.yaml: |
    color: white
    age: 31
    skinny: true
    car: ford
kind: ConfigMap
metadata:
  creationTimestamp: "2026-07-17T04:02:35Z"
  name: external-labels
  namespace: alan-external-config-test
  resourceVersion: "19720"
  uid: 24a9f992-c7d7-4dc6-b8ad-33bcf392c2b1

```
Now assets have the labels that the configmap had 

```
{
"code": 200,
"data": {
"AWS/__undefined__/__undefined__/Compute/default-cluster/Node/Kubernetes/i-03b336f2cc7c96b4e/ip-10-0-4-70.ec2.internal": {
"type": "Node",
"properties": {
"category": "Compute",
"provider": "AWS",
"service": "Kubernetes",
"cluster": "default-cluster",
"name": "ip-10-0-4-70.ec2.internal",
"providerID": "i-03b336f2cc7c96b4e"
},
"labels": {
"age": "31",
"beta_kubernetes_io_arch": "amd64",
"beta_kubernetes_io_instance_type": "c5.large",
"beta_kubernetes_io_os": "linux",
"car": "ford",
"color": "white",
"eks_amazonaws_com_capacityType": "ON_DEMAND",
"eks_amazonaws_com_nodegroup": "jolly_mirzakhani",
"eks_amazonaws_com_nodegroup_image": "ami-0d999941360091a98",
"failure_domain_beta_kubernetes_io_region": "us-east-1",
"failure_domain_beta_kubernetes_io_zone": "us-east-1a",
"k8s_io_cloud_provider_aws": "788abeed12c3374f2a861c4e58c6162e",
"kubernetes_io_arch": "amd64",
"kubernetes_io_hostname": "ip-10-0-4-70.ec2.internal",
"kubernetes_io_os": "linux",
"node_kubernetes_io_instance_type": "c5.large",
"providerID": "aws:///us-east-1a/i-03b336f2cc7c96b4e",
"skinny": "true",
"topology_ebs_csi_aws_com_zone": "us-east-1a",
"topology_k8s_aws_zone_id": "use1-az1",
"topology_kubernetes_io_region": "us-east-1",
"topology_kubernetes_io_zone": "us-east-1a"
},
```

The labels are showing on the assets as expected.

Linked Jira ticket: https://apptio.atlassian.net/browse/KCM-6023