### PR TITLE
feat(opencost): expose AWS RI/SP Athena refresh interval

### DIFF
--- a/charts/opencost/Chart.yaml
+++ b/charts/opencost/Chart.yaml
@@ -9,7 +9,7 @@ keywords:
   - finops
   - monitoring
   - opencost
-version: 2.5.28
+version: 2.5.29
 maintainers:
   - name: jessegoodier
   - name: toscott

--- a/charts/opencost/README.md
+++ b/charts/opencost/README.md
@@ -78,6 +78,7 @@ $ helm install opencost opencost/opencost
 | opencost.exporter.apiIngress.tls | list | `[]` | Ingress TLS configuration |
 | opencost.exporter.apiPort | int | `9003` |  |
 | opencost.exporter.aws.access_key_id | string | `""` | AWS secret key id |
+| opencost.exporter.aws.riSpRefreshRateHours | int | `1` | Number of hours between refreshes of Reserved Instance and Savings Plan data from Athena. Defaults to 1 (hourly). For multi-cluster deployments sharing a single CUR export, raise this (e.g. 24) to reduce Athena scan cost. |
 | opencost.exporter.aws.secret_access_key | string | `""` | AWS secret access key |
 | opencost.exporter.cloudProviderApiKey | string | `""` | The GCP Pricing API requires a key. This is supplied just for evaluation. |
 | opencost.exporter.collectorDataSource.enabled | bool | `false` |  |

--- a/charts/opencost/templates/deployment.yaml
+++ b/charts/opencost/templates/deployment.yaml
@@ -325,6 +325,8 @@ spec:
               value: {{ .Values.opencost.cloudCost.queryWindowDays | quote }}
             - name: CLOUD_COST_RUN_WINDOW_DAYS
               value: {{ .Values.opencost.cloudCost.runWindowDays | quote }}
+            - name: AWS_RI_SP_REFRESH_RATE_HOURS
+              value: {{ .Values.opencost.exporter.aws.riSpRefreshRateHours | quote }}
             {{- if not (quote .Values.opencost.metrics.kubeStateMetrics.emitPodAnnotations | empty ) }}
             - name: EMIT_POD_ANNOTATIONS_METRIC
               value: {{ .Values.opencost.metrics.kubeStateMetrics.emitPodAnnotations | quote }}

--- a/charts/opencost/values.yaml
+++ b/charts/opencost/values.yaml
@@ -173,7 +173,8 @@ opencost:
   #         "athenaTable": "AWS_cloud_integration_athenaTable",
   #         "projectID": "AWS_cloud_integration_athena_projectID",
   #         "serviceKeyName": "AWS_cloud_integration_athena_serviceKeyName",
-  #         "serviceKeySecret": "AWS_cloud_integration_athena_serviceKeySecret"
+  #         "serviceKeySecret": "AWS_cloud_integration_athena_serviceKeySecret",
+  #         "resultReuseMaxAgeMinutes": 60
   #       }
   #     ],
   #     "azure": [
@@ -435,6 +436,8 @@ opencost:
       secret_access_key: ""
       # -- AWS secret key id
       access_key_id: ""
+      # -- Number of hours between refreshes of Reserved Instance and Savings Plan data from Athena. Defaults to 1 (hourly). For multi-cluster deployments sharing a single CUR export, raise this (e.g. 24) to reduce Athena scan cost.
+      riSpRefreshRateHours: 1
     # -- A list of volume mounts to be added to the pod
     extraVolumeMounts: []
     # -- List of additional environment variables to set in the container


### PR DESCRIPTION
## Description

Complements two OpenCost changes that reduce AWS Athena scan cost, exposing/documenting them in the chart:

1. **RI/SP refresh interval** (opencost/opencost#3977) — wires a new `opencost.exporter.aws.riSpRefreshRateHours` value (default `1`) to the `AWS_RI_SP_REFRESH_RATE_HOURS` environment variable on the exporter deployment. Controls how often the Reserved Instance and Savings Plan watchers refresh from Athena (previously hardcoded to 1h).
2. **Athena result-reuse caching** (opencost/opencost#3953) — documents the `resultReuseMaxAgeMinutes` field in the `cloudIntegrationJSON` example. This field lives in `cloud-integration.json` (passed through opaquely by the chart), so it needs no wiring — the example just makes it discoverable.

Changes:
- `values.yaml`: add `opencost.exporter.aws.riSpRefreshRateHours: 1`; add `resultReuseMaxAgeMinutes` to the `cloudIntegrationJSON` example
- `deployment.yaml`: `AWS_RI_SP_REFRESH_RATE_HOURS` env sourced from that value
- `README.md`: regenerated values table
- `Chart.yaml`: version 2.5.28 → 2.5.29

## Dependency

The `AWS_RI_SP_REFRESH_RATE_HOURS` env var only takes effect once an OpenCost image containing opencost/opencost#3977 ships; older images ignore it (safe to merge). The `resultReuseMaxAgeMinutes` field requires opencost/opencost#3953.

## User Impact

Backward compatible. `riSpRefreshRateHours` defaults to `1`, reproducing today's hourly behavior. Multi-cluster deployments sharing a single CUR export can raise it (e.g. `24`) and/or set `resultReuseMaxAgeMinutes` to cut Athena scan cost.

## Testing

- `helm lint charts/opencost`
- `helm template charts/opencost | grep -A1 AWS_RI_SP_REFRESH_RATE_HOURS` → renders `value: "1"`
- With `--set opencost.exporter.aws.riSpRefreshRateHours=24` → renders `value: "24"`
