### PR TITLE
feat: add opencost.exporter.extraEnvFrom to source env from ConfigMap/Secret

### DIFF
--- a/charts/opencost/Chart.yaml
+++ b/charts/opencost/Chart.yaml
@@ -9,7 +9,7 @@ keywords:
   - finops
   - monitoring
   - opencost
-version: 2.5.29
+version: 2.5.30
 maintainers:
   - name: jessegoodier
   - name: toscott

--- a/charts/opencost/README.md
+++ b/charts/opencost/README.md
@@ -2,7 +2,7 @@
 
 OpenCost and OpenCost UI
 
-![Version: 2.5.28](https://img.shields.io/badge/Version-2.5.28-informational?style=flat-square)
+![Version: 2.5.30](https://img.shields.io/badge/Version-2.5.30-informational?style=flat-square)
 ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
 ![AppVersion: 1.121.0](https://img.shields.io/badge/AppVersion-1.121.0-informational?style=flat-square)
 [![Artifact Hub](https://img.shields.io/endpoint?url=https://artifacthub.io/badge/repository/opencost)](https://artifacthub.io/packages/search?repo=opencost)
@@ -92,6 +92,7 @@ $ helm install opencost opencost/opencost
 | opencost.exporter.env | list | `[]` | List of additional environment variables to set in the container |
 | opencost.exporter.extraArgs | list | `[]` | List of extra arguments for the command, e.g.: log-format=json |
 | opencost.exporter.extraEnv | object | `{}` | Any extra environment variables you would like to pass on to the pod |
+| opencost.exporter.extraEnvFrom | list | `[]` | Extra environment variables from secrets or configmaps |
 | opencost.exporter.extraVolumeMounts | list | `[]` | A list of volume mounts to be added to the pod |
 | opencost.exporter.image | object | `{"fullImageName":null,"pullPolicy":"IfNotPresent","registry":"ghcr.io","repository":"opencost/opencost","tag":"1.121.0@sha256:2b0def286f343891b2cb2f10309d92bd614aab2f886e363cdc817dfd8595e472"}` | Exporter container image configuration |
 | opencost.exporter.image.fullImageName | string | `nil` | Override the full image name for development purposes |

--- a/charts/opencost/templates/deployment.yaml
+++ b/charts/opencost/templates/deployment.yaml
@@ -376,6 +376,10 @@ spec:
             - name: MCP_SERVER_ENABLED
               value: "false"
             {{- end }}
+          {{- with .Values.opencost.exporter.extraEnvFrom }}
+          envFrom:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
           {{- if or .Values.plugins.enabled .Values.opencost.exporter.persistence.enabled .Values.opencost.exporter.extraVolumeMounts .Values.opencost.customPricing.enabled .Values.opencost.metrics.config.enabled $cloudIntegrationSecretName .Values.opencost.updateCaTrust.enabled}}
           volumeMounts:
             {{- if .Values.plugins.enabled }}

--- a/charts/opencost/values.yaml
+++ b/charts/opencost/values.yaml
@@ -444,6 +444,12 @@ opencost:
       # FOO: BAR
       # For example, if accessing mimir directly and getting 401 Unauthorized
       # PROMETHEUS_HEADER_X_SCOPE_ORGID: anonymous
+    # -- Extra environment variables from secrets or configmaps
+    extraEnvFrom: []
+      # - configMapRef:
+      #     name: opencost-env
+      # - secretRef:
+      #     name: opencost-env-secret
     # Admin token for write operations (e.g. POST /serviceKey, cloud config endpoints).
     # Set ADMIN_TOKEN env from a chart-created secret or an existing secret.
     adminToken:


### PR DESCRIPTION
`opencost.exporter.extraEnv` only renders literal name/value pairs, so an exporter env var whose value is not known when the values file is written cannot be supplied.

Typical case: values that are only known in the cluster at deploy time, or values that belong in a Secret rather than in chart values.

```yaml
opencost:
  exporter:
    extraEnvFrom:
      - configMapRef:
          name: opencost-env
      - secretRef:
          name: opencost-env-secret
```
Explicit `env:` entries win over `envFrom` in Kubernetes, so everything the chart sets explicitly (including `extraEnv`) keeps precedence.

Chart version bumped to 2.5.30; README table row and version badge updated accordingly.


## How was this tested

`helm template` with the values above renders on the exporter container:

```yaml
envFrom:
  - configMapRef:
      name: opencost-env
  - secretRef:
      name: opencost-env-secret
```

With the value unset, no `envFrom` is rendered (unchanged output).
`helm lint` and `helm unittest charts/opencost -f 'tests/plugins_test.yaml'` pass.