### PR TITLE
Add an opt-in PodMonitor for model-server pods

### DIFF
--- a/charts/opencost/Chart.yaml
+++ b/charts/opencost/Chart.yaml
@@ -9,7 +9,7 @@ keywords:
   - finops
   - monitoring
   - opencost
-version: 2.5.29
+version: 2.5.30
 maintainers:
   - name: jessegoodier
   - name: toscott

--- a/charts/opencost/README.md
+++ b/charts/opencost/README.md
@@ -102,6 +102,17 @@ $ helm install opencost opencost/opencost
 | opencost.exporter.inferenceCostTracking.collectionInterval | string | `"2m"` | Background collection interval |
 | opencost.exporter.inferenceCostTracking.enabled | bool | `false` | Enable inference cost tracking |
 | opencost.exporter.inferenceCostTracking.modelLabel | string | `"llm-d.ai/model"` | Pod label whose value is the vLLM model name. Must match the model_name label on vLLM Prometheus metrics |
+| opencost.exporter.inferenceCostTracking.podMonitor.additionalLabels | object | `{}` | Additional labels to add to the PodMonitor |
+| opencost.exporter.inferenceCostTracking.podMonitor.additionalSelectorLabels | object | `{}` | Additional label selectors ANDed with the model-label existence check |
+| opencost.exporter.inferenceCostTracking.podMonitor.enabled | bool | `false` | Create a PodMonitor that scrapes model-server pods with the relabel rules OpenCost requires (needs Prometheus Operator) |
+| opencost.exporter.inferenceCostTracking.podMonitor.extraRelabelings | list | `[]` | RelabelConfigs appended after the identity rules OpenCost requires |
+| opencost.exporter.inferenceCostTracking.podMonitor.metricRelabelings | list | `[]` | MetricRelabelConfigs to apply to samples before ingestion |
+| opencost.exporter.inferenceCostTracking.podMonitor.namespace | string | `""` | Deploy the PodMonitor into a different namespace (blank deploys into the same namespace as the chart) |
+| opencost.exporter.inferenceCostTracking.podMonitor.namespaces | list | `[]` | Namespaces to search for model-server pods (empty selects all namespaces) |
+| opencost.exporter.inferenceCostTracking.podMonitor.path | string | `"/metrics"` | Path of the engine's metrics endpoint |
+| opencost.exporter.inferenceCostTracking.podMonitor.portName | string | `"metrics"` | Name of the pod port exposing the engine's metrics endpoint |
+| opencost.exporter.inferenceCostTracking.podMonitor.scrapeInterval | string | `30s` | Interval at which model-server metrics should be scraped |
+| opencost.exporter.inferenceCostTracking.podMonitor.scrapeTimeout | string | `10s` | Timeout after which the scrape is ended |
 | opencost.exporter.inferenceCostTracking.sharedInfraLabel | string | `"llm-d.ai/inference-shared"` | Pod label key identifying shared infra pods (EPP, gateway) |
 | opencost.exporter.inferenceCostTracking.sharedInfraLabelValue | string | `"true"` | Label value that marks a pod as shared infra |
 | opencost.exporter.livenessProbe.enabled | bool | `true` | Whether probe is enabled |

--- a/charts/opencost/templates/podmonitor-inference.yaml
+++ b/charts/opencost/templates/podmonitor-inference.yaml
@@ -1,0 +1,56 @@
+{{- if .Values.opencost.exporter.inferenceCostTracking.podMonitor.enabled -}}
+apiVersion: monitoring.coreos.com/v1
+kind: PodMonitor
+metadata:
+  name: {{ include "opencost.fullname" . }}-inference
+  {{- if .Values.opencost.exporter.inferenceCostTracking.podMonitor.namespace }}
+  namespace: {{ .Values.opencost.exporter.inferenceCostTracking.podMonitor.namespace | quote }}
+  {{- end }}
+  labels:
+    {{- include "opencost.labels" . | nindent 4 }}
+    {{- if .Values.opencost.exporter.inferenceCostTracking.podMonitor.additionalLabels }}
+      {{- toYaml .Values.opencost.exporter.inferenceCostTracking.podMonitor.additionalLabels | nindent 4 }}
+    {{- end }}
+spec:
+  podMetricsEndpoints:
+    - port: {{ .Values.opencost.exporter.inferenceCostTracking.podMonitor.portName | quote }}
+      path: {{ .Values.opencost.exporter.inferenceCostTracking.podMonitor.path | quote }}
+      interval: {{ .Values.opencost.exporter.inferenceCostTracking.podMonitor.scrapeInterval }}
+      scrapeTimeout: {{ .Values.opencost.exporter.inferenceCostTracking.podMonitor.scrapeTimeout }}
+      relabelings:
+        # Serving engines report model_name but nothing about where they run, so
+        # the Kubernetes identity has to be attached at scrape time.
+        #
+        # pod_uid is what OpenCost joins these metrics to the rest of its
+        # Kubernetes model on. A pod name is reused across a pod's lifetime, so
+        # name-based joins silently merge a recreated pod with its predecessor.
+        # Without pod_uid the saturation signals are dropped rather than
+        # mis-attributed.
+        - sourceLabels: [__meta_kubernetes_namespace]
+          targetLabel: namespace
+        - sourceLabels: [__meta_kubernetes_pod_name]
+          targetLabel: pod
+        - sourceLabels: [__meta_kubernetes_pod_uid]
+          targetLabel: pod_uid
+        {{- with .Values.opencost.exporter.inferenceCostTracking.podMonitor.extraRelabelings }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+      {{- with .Values.opencost.exporter.inferenceCostTracking.podMonitor.metricRelabelings }}
+      metricRelabelings: {{- toYaml . | nindent 8 }}
+      {{- end }}
+  selector:
+    matchExpressions:
+      # Select model-server pods by the presence of the model label, the same
+      # label OpenCost reads the model name from.
+      - key: {{ .Values.opencost.exporter.inferenceCostTracking.modelLabel | quote }}
+        operator: Exists
+    {{- with .Values.opencost.exporter.inferenceCostTracking.podMonitor.additionalSelectorLabels }}
+    matchLabels: {{- toYaml . | nindent 6 }}
+    {{- end }}
+  namespaceSelector:
+    {{- if .Values.opencost.exporter.inferenceCostTracking.podMonitor.namespaces }}
+    matchNames: {{- toYaml .Values.opencost.exporter.inferenceCostTracking.podMonitor.namespaces | nindent 6 }}
+    {{- else }}
+    any: true
+    {{- end }}
+{{- end }}

--- a/charts/opencost/values.yaml
+++ b/charts/opencost/values.yaml
@@ -429,6 +429,36 @@ opencost:
       sharedInfraLabelValue: "true"
       # -- Background collection interval
       collectionInterval: "2m"
+      # PodMonitor for model-server pods. OpenCost reads vLLM's metrics from
+      # your Prometheus; it does not scrape them itself. Those metrics must
+      # carry the pod's Kubernetes identity, and pod_uid in particular, or the
+      # engine saturation signals cannot be joined to the Kubernetes model and
+      # are dropped. Enable this to have the chart create a PodMonitor that
+      # attaches namespace, pod and pod_uid, or add the equivalent relabel
+      # rules to your own scrape job.
+      podMonitor:
+        # -- Create a PodMonitor that scrapes model-server pods with the relabel rules OpenCost requires (needs Prometheus Operator)
+        enabled: false
+        # -- Additional labels to add to the PodMonitor
+        additionalLabels: {}
+        # -- Deploy the PodMonitor into a different namespace (blank deploys into the same namespace as the chart)
+        namespace: ""
+        # -- Namespaces to search for model-server pods (empty selects all namespaces)
+        namespaces: []
+        # -- Name of the pod port exposing the engine's metrics endpoint
+        portName: "metrics"
+        # -- Path of the engine's metrics endpoint
+        path: "/metrics"
+        # -- Interval at which model-server metrics should be scraped
+        scrapeInterval: 30s
+        # -- Timeout after which the scrape is ended
+        scrapeTimeout: 10s
+        # -- Additional label selectors ANDed with the model-label existence check
+        additionalSelectorLabels: {}
+        # -- RelabelConfigs appended after the identity rules OpenCost requires
+        extraRelabelings: []
+        # -- MetricRelabelConfigs to apply to samples before ingestion
+        metricRelabelings: []
 
     aws:
       # -- AWS secret access key


### PR DESCRIPTION
Draft, paired with opencost/opencost#3915.

## Why

OpenCost reads vLLM's metrics from the user's Prometheus rather than scraping them itself, so those series only carry whatever Kubernetes identity the scrape job attaches. The engine reports `model_name` and nothing about where it runs.

opencost/opencost#3915 joins model-server telemetry to the rest of the Kubernetes model on **`pod_uid`**, for the same reason every other entity joins by UID: a pod name is reused across a pod's lifetime, so a name-based join silently merges a recreated pod with its predecessor. Series arriving without `pod_uid` are dropped rather than mis-attributed.

The practical consequence is that on a default install, engine saturation data is simply **absent** via the Prometheus path unless the operator knows to hand-write the relabel rule. This chart had no vLLM scrape job to add that rule to.

## What

A `PodMonitor`, **disabled by default**, that selects pods carrying the configured model label (`inferenceCostTracking.modelLabel`, default `llm-d.ai/model`) and attaches `namespace`, `pod` and `pod_uid`.

Operators who already scrape their model servers can keep doing so and add the `pod_uid` rule to their own job; this just removes the need to know it is required.

## Notes for reviewers

- Requires Prometheus Operator, same assumption as the existing `serviceMonitor` block.
- Namespace-scoped by default to all namespaces (`any: true`); settable via `podMonitor.namespaces`.
- Port name defaults to `metrics`; vLLM deployments vary here, so it is configurable.
- `helm lint` passes; verified rendering with the PodMonitor on and off, and with an explicit namespace list.
- README value table hand-edited to match helm-docs output format (helm-docs was not available locally, so it is worth regenerating).

Open question: should this live here at all, or is scraping a user's own workloads outside this chart's remit, with documentation being the better answer? Happy to reduce it to docs if that is the preference.