### PR TITLE
added default value to helm chart values for customPricing.costModel.discount

### DIFF
--- a/charts/opencost/values.yaml
+++ b/charts/opencost/values.yaml
@@ -539,6 +539,7 @@ opencost:
     # -- More information about these values here: https://www.opencost.io/docs/configuration/on-prem#custom-pricing-using-the-opencost-helm-chart
     costModel:
       description: Modified pricing configuration.
+      discount: ""
       CPU: 1.25
       spotCPU: 0.006655
       RAM: 0.50


### PR DESCRIPTION
Closes: #380 
Added default helm value for "customPricing.costModel.discount" at charts/opencost/values.yaml. 

Application has logic that use this value as AWS discount which can be used to adjust k8s resources cost. It's just not exposed in values.yaml.
```func (aws *AWS) GetConfig() (*models.CustomPricing, error) {
	c, err := aws.Config.GetCustomPricingData()
	if err != nil {
		return nil, err
	}
	if c.Discount == "" {
		c.Discount = "0%"
	}
	if c.NegotiatedDiscount == "" {
		c.NegotiatedDiscount = "0%"
	}

	return c, nil
}
```
Application code link: https://github.com/opencost/opencost/blob/e977d842ed2ae977726f29637061df0bac352ac6/pkg/cloud/aws/provider.go#L483

Helm values link: https://github.com/opencost/opencost-helm-chart/blob/4242feee70e745ea540fc5d3177d4899b307dc2d/charts/opencost/values.yaml#L540

Values example: 
```
customPricing:
    costModel:
      discount: ""
```
